### PR TITLE
[UPDATE] Adjust send SMS layout and validation rule

### DIFF
--- a/src/components/admin/AdminModal.tsx
+++ b/src/components/admin/AdminModal.tsx
@@ -32,7 +32,7 @@ const StyledTitle = styled.h1`
   letter-spacing: 0.77;
 `
 
-export type AdminModalProps = ModalProps & {
+export type AdminModalProps = Omit<ModalProps, 'onOk'> & {
   renderTrigger?: React.FC<{
     setVisible: React.Dispatch<React.SetStateAction<boolean>>
   }>
@@ -40,7 +40,12 @@ export type AdminModalProps = ModalProps & {
   renderFooter?: React.FC<{
     setVisible: React.Dispatch<React.SetStateAction<boolean>>
   }>
+  onOk?: (
+		e: React.MouseEvent<HTMLElement>,
+		setVisible: React.Dispatch<React.SetStateAction<boolean>>
+	) => void;
 }
+
 const AdminModal: React.FC<AdminModalProps> = ({
   title,
   renderTrigger,
@@ -48,6 +53,7 @@ const AdminModal: React.FC<AdminModalProps> = ({
   children,
   icon,
   onCancel,
+  onOk,
   ...ModalProps
 }) => {
   const [visible, setVisible] = useState(false)
@@ -64,6 +70,9 @@ const AdminModal: React.FC<AdminModalProps> = ({
         onCancel={e => {
           onCancel?.(e)
           setVisible(false)
+        }}
+        onOk={async e => {
+          onOk?.(e, setVisible)
         }}
         {...ModalProps}
       >

--- a/src/components/member/MemberNoteAdminItem.tsx
+++ b/src/components/member/MemberNoteAdminItem.tsx
@@ -82,7 +82,7 @@ const MemberNoteAdminItem: React.FC<{
                     null
                   }
                 />
-                {note.status === 'answered' && (
+                {note.status === 'answered' && note.type !== 'sms' && (
                   <span className="ml-2">{moment.utc((note?.duration ?? 0) * 1000).format('HH:mm:ss')}</span>
                 )}
                 {note.status === 'missed' && (

--- a/src/helpers/translation.ts
+++ b/src/helpers/translation.ts
@@ -1122,6 +1122,12 @@ export const memberMessages = {
     endedAt: { id: 'member.text.endedAt', defaultMessage: '結束時間：{time}' },
     unavailableContract: { id: 'member.text.unavailableContract', defaultMessage: '此合約已失效' },
     searchNoteRecord: { id: 'member.text.searchNoteRecord', defaultMessage: '搜尋聯絡紀錄' },
+    smsSucceed: { id: 'member.text.smsSucceed', defaultMessage: '簡訊寄送成功' },
+    smsFailed: { id: 'member.text.smsFailed', defaultMessage: '簡訊寄送失敗: {errorMessage}' },
+  },
+  placeholder: {
+    smsContent: { id: 'member.placeholder.smsContent', defaultMessage: '請輸入訊息內容，單封字數勿超過69字' },
+    smsSchedule: { id: 'member.placeholder.smsSchedule', defaultMessage: '排程發送時間（選填）' },
   },
 }
 

--- a/src/helpers/translation.ts
+++ b/src/helpers/translation.ts
@@ -1124,6 +1124,7 @@ export const memberMessages = {
     searchNoteRecord: { id: 'member.text.searchNoteRecord', defaultMessage: '搜尋聯絡紀錄' },
     smsSucceed: { id: 'member.text.smsSucceed', defaultMessage: '簡訊寄送成功' },
     smsFailed: { id: 'member.text.smsFailed', defaultMessage: '簡訊寄送失敗: {errorMessage}' },
+    smsTooLong: { id: 'member.text.smsTooLong', defaultMessage: '*已超出字數69字' },
   },
   placeholder: {
     smsContent: { id: 'member.placeholder.smsContent', defaultMessage: '請輸入訊息內容，單封字數勿超過69字' },

--- a/src/pages/MemberAdminPage/MemberAdminLayout.tsx
+++ b/src/pages/MemberAdminPage/MemberAdminLayout.tsx
@@ -244,7 +244,7 @@ const MemberAdminLayout: React.FC<{
                 <StyledDescription key={phone}>
                   <Icon className="mr-2" component={() => <PhoneIcon />} />
                   <span className="mr-2">{phone}</span>
-                  {enabledModules.sms && <MemberSmsModel memberId={member.id} phone={phone} />}
+                  {enabledModules.sms && <MemberSmsModel memberId={member.id} phone={phone} name={member.name || member.username}/>}
                 </StyledDescription>
               ))}
 

--- a/src/pages/MemberAdminPage/MemberSmsModal.tsx
+++ b/src/pages/MemberAdminPage/MemberSmsModal.tsx
@@ -5,13 +5,16 @@ import axios from 'axios'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { Moment } from 'moment'
 import { useState } from 'react'
+import { useIntl } from 'react-intl'
 import AdminModal from '../../components/admin/AdminModal'
+import { memberMessages } from '../../helpers/translation'
 
 const MemberSmsModel: React.VFC<{ memberId: string; phone: string, name: string }> = ({ memberId, phone, name }) => {
   const [isSending, setIsSending] = useState(false)
   const [content, setContent] = useState('')
   const [sentAt, setSentAt] = useState<Moment | null>(null)
   const { authToken } = useAuth()
+  const { formatMessage } = useIntl()
 
   return (
     <AdminModal
@@ -35,9 +38,11 @@ const MemberSmsModel: React.VFC<{ memberId: string; phone: string, name: string 
           )
           .then(({ data: { code, error, result } }) => {
             if (code === 'SUCCESS') {
-              message.success('sent successfully')
+              message.success(formatMessage(memberMessages.text.smsSucceed))
             } else {
-              message.error(`sent faild: ${error}`)
+              message.error(formatMessage(memberMessages.text.smsFailed, {
+                errorMessage: error
+              }))
             }
           })
           .finally(() => {
@@ -53,7 +58,7 @@ const MemberSmsModel: React.VFC<{ memberId: string; phone: string, name: string 
       <div className="mb-3">{`${name} / ${phone}`}</div>
       <TextArea
         className="mb-3"
-        placeholder="content"
+        placeholder={formatMessage(memberMessages.placeholder.smsContent)}
         required
         value={content}
         onChange={e => setContent(e.target.value)}
@@ -61,7 +66,7 @@ const MemberSmsModel: React.VFC<{ memberId: string; phone: string, name: string 
       <DatePicker
         style={{ width: '100%' }}
         showTime
-        placeholder="scheduled date to sent (optional)"
+        placeholder={formatMessage(memberMessages.placeholder.smsSchedule)}
         value={sentAt}
         onChange={date => setSentAt(date)}
       />

--- a/src/pages/MemberAdminPage/MemberSmsModal.tsx
+++ b/src/pages/MemberAdminPage/MemberSmsModal.tsx
@@ -15,7 +15,7 @@ const MemberSmsModel: React.VFC<{ memberId: string; phone: string }> = ({ member
   return (
     <AdminModal
       okText="寄送"
-      onOk={() => {
+      onOk={(_e, setVisible) => {
         setIsSending(true)
         axios
           .post(
@@ -39,11 +39,15 @@ const MemberSmsModel: React.VFC<{ memberId: string; phone: string }> = ({ member
               message.error(`sent faild: ${error}`)
             }
           })
-          .finally(() => setIsSending(false))
+          .finally(() => {
+            setVisible(false)
+            setIsSending(false)
+          })
       }}
       renderTrigger={({ setVisible }) => (
         <Icon component={() => <MessageOutlined />} onClick={() => setVisible(true)} className="cursor-pointer" />
       )}
+      confirmLoading={isSending}
     >
       <div className="mb-3">{phone}</div>
       <TextArea

--- a/src/pages/MemberAdminPage/MemberSmsModal.tsx
+++ b/src/pages/MemberAdminPage/MemberSmsModal.tsx
@@ -7,11 +7,12 @@ import { Moment } from 'moment'
 import { useState } from 'react'
 import AdminModal from '../../components/admin/AdminModal'
 
-const MemberSmsModel: React.VFC<{ memberId: string; phone: string }> = ({ memberId, phone }) => {
+const MemberSmsModel: React.VFC<{ memberId: string; phone: string, name: string }> = ({ memberId, phone, name }) => {
   const [isSending, setIsSending] = useState(false)
   const [content, setContent] = useState('')
   const [sentAt, setSentAt] = useState<Moment | null>(null)
   const { authToken } = useAuth()
+
   return (
     <AdminModal
       okText="寄送"
@@ -49,7 +50,7 @@ const MemberSmsModel: React.VFC<{ memberId: string; phone: string }> = ({ member
       )}
       confirmLoading={isSending}
     >
-      <div className="mb-3">{phone}</div>
+      <div className="mb-3">{`${name} / ${phone}`}</div>
       <TextArea
         className="mb-3"
         placeholder="content"


### PR DESCRIPTION
- SMS validation, content includes Chinese
  <img width="1582" alt="截圖 2022-09-28 08 06 27" src="https://user-images.githubusercontent.com/6468997/192658784-03c90a07-ceaf-480f-bf49-953e7b839026.png">
- SMS validation, content only contains English and numbers
  <img width="1582" alt="截圖 2022-09-28 08 07 31" src="https://user-images.githubusercontent.com/6468997/192658790-f7e53445-9f6f-48a4-80b0-4964e081e546.png">
- Hide duration when contact type is SMS
<img width="1582" alt="截圖 2022-09-28 08 07 51" src="https://user-images.githubusercontent.com/6468997/192658796-86eb16a7-3d90-430f-8609-924686124e8d.png">
- Send SMS button loading state
<img width="1582" alt="截圖 2022-09-28 08 08 08" src="https://user-images.githubusercontent.com/6468997/192658803-f1d4f881-7820-433b-9318-66d42505307e.png">
- Sent SMS succeed message
<img width="1582" alt="截圖 2022-09-28 08 08 09" src="https://user-images.githubusercontent.com/6468997/192658807-484d1422-a274-4878-9828-6c1854da2cc1.png">
