### PR TITLE
fix: modify chart color and text

### DIFF
--- a/src/pages/MediaLibraryPage/MediaLibraryUsageCard.tsx
+++ b/src/pages/MediaLibraryPage/MediaLibraryUsageCard.tsx
@@ -1,8 +1,7 @@
 import { DualAxes } from '@ant-design/charts'
 import { DualAxesConfig } from '@ant-design/plots'
-import { useQuery } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { DatePicker } from 'antd'
-import { gql } from '@apollo/client'
 import { max, sum } from 'lodash'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import moment, { Moment } from 'moment'
@@ -19,12 +18,12 @@ const MediaLibraryUsageCard: React.VFC = () => {
     const data = ticks.map(tick => ({
       dateHour: tick.dateHour.format('MM/DD HH:00'),
       videoDuration: Math.round(tick.videoDuration / 60),
-      watchedSeconds: Math.round(tick.watchedSeconds / 60),
+      watchedMinutes: Math.round(tick.watchedSeconds / 60),
     }))
     const config: DualAxesConfig = {
       data: [data, data],
       xField: 'dateHour',
-      yField: ['videoDuration', 'watchedSeconds'],
+      yField: ['videoDuration', 'watchedMinutes'],
       xAxis: {
         label: {
           autoRotate: true,
@@ -34,9 +33,11 @@ const MediaLibraryUsageCard: React.VFC = () => {
       geometryOptions: [
         {
           geometry: 'column',
+          color: '#4ED1B3',
         },
         {
           geometry: 'line',
+          color: '#4C5B8F',
           lineStyle: {
             lineWidth: 2,
           },


### PR DESCRIPTION
- modify chart color and text

- requirement
(ignore)1.寫 metabase 查看哪些客戶用量超過
2.圖表調整顏色，目前顏色與後台使用的不一致
Duration: #4ED1B3
Watched: #4C5B8F
3.圖表的圖說是顯示
WatchedSeconds -> 改為「WatchedMinutes」應該是分鐘不是秒