### PR TITLE
fix: ProjectPortfolio published tab display bug

### DIFF
--- a/src/components/project/ProjectCollectionBlock.tsx
+++ b/src/components/project/ProjectCollectionBlock.tsx
@@ -35,7 +35,6 @@ const ProjectCollectionBlock: React.FC<{
         ...condition,
         title: search ? { _like: `%${search}%` } : undefined,
       },
-      currentMemberId || '',
       orderBy,
     )
   const {
@@ -150,7 +149,6 @@ const ProjectCollectionBlock: React.FC<{
 
 const useProjectPreviewCollection = (
   condition: hasura.GET_PROJECT_PREVIEW_COLLECTIONVariables['condition'],
-  memberId: string,
   orderBy: hasura.GET_PROJECT_PREVIEW_COLLECTIONVariables['orderBy'] = [
     { created_at: 'desc_nulls_last' as hasura.order_by },
   ],

--- a/src/components/project/ProjectCollectionBlock.tsx
+++ b/src/components/project/ProjectCollectionBlock.tsx
@@ -77,7 +77,7 @@ const ProjectCollectionBlock: React.FC<{
 
   return (
     <>
-      {withSortingButton && (
+      {withSortingButton && projectType !== 'portfolio' && (
         <div className="text-right">
           <ItemsSortingModal
             items={projectSorts}
@@ -193,7 +193,7 @@ const useProjectPreviewCollection = (
                 ...condition,
                 ...(Object.keys(Array.isArray(orderBy) ? orderBy[0] : orderBy)[0] === 'position'
                   ? { position: { _gt: data?.project.slice(-1)[0]?.position } }
-                  : { created_at: { _lt: data?.project.slice(-1)[0]?.created_at } }),
+                  : { published_at: { _lt: data?.project.slice(-1)[0]?.published_at } }),
               },
               limit: 10,
             },

--- a/src/components/project/ProjectCollectionTable.tsx
+++ b/src/components/project/ProjectCollectionTable.tsx
@@ -63,12 +63,6 @@ const ProjectCollectionTable: React.FC<{
       ),
     },
     {
-      key: 'author',
-      width: '20%',
-      title: formatMessage(projectMessages.ProjectCollectionTable.author),
-      render: (text, record, index) => <StyledAuthorName>{record.author?.name}</StyledAuthorName>,
-    },
-    {
       width: '10%',
       filterDropdown: () => (
         <div className="p-2">
@@ -84,6 +78,12 @@ const ProjectCollectionTable: React.FC<{
         </div>
       ),
       filterIcon,
+    },
+    {
+      key: 'author',
+      width: '20%',
+      title: formatMessage(projectMessages.ProjectCollectionTable.author),
+      render: (text, record, index) => <StyledAuthorName>{record.author?.name}</StyledAuthorName>,
     },
   ]
 

--- a/src/components/project/ProjectCollectionTabs.tsx
+++ b/src/components/project/ProjectCollectionTabs.tsx
@@ -46,7 +46,10 @@ const ProjectCollectionTabs: React.FC<{ projectType: ProjectDataType }> = ({ pro
         _or: [{ expired_at: { _gt: 'now()' } }, { expired_at: { _is_null: true } }],
         creator_id: creatorId,
       },
-      orderBy: [{ published_at: 'desc' as hasura.order_by }, { position: 'asc' as hasura.order_by }],
+      orderBy:
+        projectType === 'portfolio'
+          ? { published_at: 'desc' as hasura.order_by }
+          : [{ published_at: 'desc' as hasura.order_by }, { position: 'asc' as hasura.order_by }],
       withSortingButton: true,
     },
     {


### PR DESCRIPTION
- fix ProjectPortfolio published tab display bug
- 後臺右邊手動「專案排序」功能先拿掉，修正專案重複的問題，且發布時間最新的會往前排。

requirement:
取消發佈再重新發佈，作品列表多了一個重複的「Maserati Greacale 【馭見不凡篇】」