### PR TITLE
fix: modify GET_PRACTICE_PREVIEW_COLLECTION condition

### DIFF
--- a/src/pages/PracticeCollectionAdminPage.tsx
+++ b/src/pages/PracticeCollectionAdminPage.tsx
@@ -1,7 +1,6 @@
 import Icon from '@ant-design/icons'
-import { useQuery } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { Input, Select, Skeleton } from 'antd'
-import { gql } from '@apollo/client'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import React, { useCallback, useRef, useState } from 'react'
@@ -177,6 +176,7 @@ const usePracticePreviewCollection = (
   const condition: hasura.GET_PRACTICE_PREVIEW_COLLECTIONVariables['condition'] = {
     _or: [
       { member: { username: { _like: options?.searchText ? `%${options.searchText}%` : undefined } } },
+      { member: { name: { _like: options?.searchText ? `%${options.searchText}%` : undefined } } },
       { title: { _like: options?.searchText ? `%${options.searchText}%` : undefined } },
     ],
     program_content: {


### PR DESCRIPTION
- modify GET_PRACTICE_PREVIEW_COLLECTION condition for practice search

requirement:
https://www.kimibarre.net/admin/practices
這個頁面中，無法以使用者名稱搜尋繳交的作業。

經查發現：送出的 variable 應該要是

```
{
  "condition": {
    "_or": [
      {
        "member": {
          "name": {
            "_like": "%洪璟旎%"
          }
        }
      },
      {
        "title": {
          "_like": "%洪璟旎%"
        }
      }
    ],
......
  "limit": 20
}
```

原本送出的是

```
{
  "condition": {
    "_or": [
      {
        "member": {
          "username": {
            "_like": "%洪璟旎%"
          }
        }
      },
      {
        "title": {
          "_like": "%洪璟旎%"
        }
      }
    ],
......
  "limit": 20
}
```

據改即可。