### PR TITLE
fix: modify finished activities query condition

### DIFF
--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -44,7 +44,6 @@ const ActivityCollectionTabs: React.FC<{
     },
     finished: {
       organizer_id: { _eq: memberId },
-      is_private: { _eq: false },
       published_at: { _is_null: false },
       activity_during_period: { ended_at: { _lt: 'now()' } },
     },


### PR DESCRIPTION
- modify finished activities query condition

requirement:
後台活動列表頁找不到 應該是判斷那邊有問題

https://ezlearn.mdnkids.com/admin/activities/eaa5b633-f729-431e-bc08-108c25a41e83

DC：https://discord.com/channels/753127151578120273/1125381013263101974/1125382480636153866