### PR TITLE
fix: remove ActivityCollectionTabs onChange event

### DIFF
--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -57,8 +57,10 @@ const ActivityCollectionTabs: React.FC<{
       activity_during_period: { ended_at: { _gt: 'now()' } },
     },
   }
-  const { loadingActivities, activities, currentTabActivityCount, loadMoreActivities, refetchActivities } =
-    useActivityCollection(condition[currentTab], selectedCategoryId)
+  const { loadingActivities, activities, currentTabActivityCount, loadMoreActivities } = useActivityCollection(
+    condition[currentTab],
+    selectedCategoryId,
+  )
   const { categories } = useCategoryCollection(condition[currentTab])
 
   if (!loadingActivities && currentTabActivityCount && !counts[currentTab]) {
@@ -91,7 +93,6 @@ const ActivityCollectionTabs: React.FC<{
   return (
     <Tabs
       defaultActiveKey={'holding'}
-      onChange={() => refetchActivities()}
       onTabClick={key => {
         setCurrentTab(key as Tab)
         setSelectedCategoryId(null)


### PR DESCRIPTION
- fix ActivityCollectionTabs refetch activities bug when change tab
requirement:
https://discord.com/channels/753127151578120273/1125381013263101974
