### PR TITLE
feat: add not individually sale checkbox in PodcastProgramPlanForm

### DIFF
--- a/src/components/podcast/PodcastProgramPlanForm.tsx
+++ b/src/components/podcast/PodcastProgramPlanForm.tsx
@@ -1,7 +1,7 @@
 import { gql, useMutation } from '@apollo/client'
 import { Button, Checkbox, Form, InputNumber, message, Skeleton } from 'antd'
 import { useForm } from 'antd/lib/form/Form'
-import React, { useEffect, useState } from 'react'
+import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
 import hasura from '../../hasura'
 import { handleError } from '../../helpers'
@@ -27,12 +27,6 @@ const PodcastProgramPlanForm: React.FC<{
   >(UPDATE_PODCAST_PROGRAM_PLAN)
   const [loading, setLoading] = useState(false)
   const [isIndividuallySale, setIsIndividuallySale] = useState(!!podcastProgramAdmin?.isIndividuallySale)
-
-  useEffect(() => {
-    if (podcastProgramAdmin) {
-      setIsIndividuallySale(podcastProgramAdmin.isIndividuallySale)
-    }
-  }, [podcastProgramAdmin])
 
   if (!podcastProgramAdmin) {
     return <Skeleton active />

--- a/src/components/podcast/PodcastProgramPlanForm.tsx
+++ b/src/components/podcast/PodcastProgramPlanForm.tsx
@@ -26,7 +26,7 @@ const PodcastProgramPlanForm: React.FC<{
     hasura.UPDATE_PODCAST_PROGRAM_PLANVariables
   >(UPDATE_PODCAST_PROGRAM_PLAN)
   const [loading, setLoading] = useState(false)
-  const [isIndividuallySale, setIsIndividuallySale] = useState(true)
+  const [isIndividuallySale, setIsIndividuallySale] = useState(!!podcastProgramAdmin?.isIndividuallySale)
 
   useEffect(() => {
     if (podcastProgramAdmin) {
@@ -45,9 +45,9 @@ const PodcastProgramPlanForm: React.FC<{
         updatedAt: new Date(),
         podcastProgramId: podcastProgramAdmin.id,
         isIndividuallySale: isIndividuallySale,
-        listPrice: values.listPrice ? values.listPrice : podcastProgramAdmin.listPrice,
-        salePrice: values.sale ? values.sale.price : null,
-        soldAt: values.sale?.soldAt || null,
+        listPrice: isIndividuallySale ? values.listPrice : 0,
+        salePrice: isIndividuallySale && values.sale ? values.sale.price : null,
+        soldAt: isIndividuallySale ? values.sale?.soldAt : null,
       },
     })
       .then(() => {

--- a/src/components/podcast/translation.ts
+++ b/src/components/podcast/translation.ts
@@ -1,0 +1,10 @@
+import { defineMessages } from 'react-intl'
+
+const podcastMessages = {
+  PodcastProgramPlanForm: defineMessages({
+    notIndividuallySale: { id: 'podcast.PodcastProgramPlanForm.notIndividuallySale', defaultMessage: 'Not individually sale' },
+  }),
+  
+}
+
+export default podcastMessages

--- a/src/hooks/podcast.ts
+++ b/src/hooks/podcast.ts
@@ -111,6 +111,7 @@ export const usePodcastProgramAdmin = (podcastProgramId: string) => {
           published_at
           creator_id
           support_locales
+          is_individually_sale
           podcast_program_audios(where: { deleted_at: { _is_null: true } }, order_by: { position: asc }) {
             id
             data
@@ -189,6 +190,7 @@ export const usePodcastProgramAdmin = (podcastProgramId: string) => {
       })),
       tags: data.podcast_program_by_pk.podcast_program_tags.map(podcastProgramTag => podcastProgramTag.tag?.name || ''),
       audios: podcastProgramAudiosFromRawAudios(data.podcast_program_by_pk.podcast_program_audios),
+      isIndividuallySale: data.podcast_program_by_pk.is_individually_sale,
     }
   }, [loading, error, data])
 

--- a/src/hooks/podcast.ts
+++ b/src/hooks/podcast.ts
@@ -157,40 +157,42 @@ export const usePodcastProgramAdmin = (podcastProgramId: string) => {
       })
     | null
   >(() => {
-    if (loading || error || !data || !data.podcast_program_by_pk) {
-      return null
-    }
-
     return {
-      id: data.podcast_program_by_pk.id,
-      title: data.podcast_program_by_pk.title || '',
-      contentType: data.podcast_program_by_pk.content_type || null,
-      filename: data.podcast_program_by_pk.filename || null,
-      duration: data.podcast_program_by_pk.duration,
-      durationSecond: data.podcast_program_by_pk.duration_second,
-      description: data.podcast_program_by_pk.podcast_program_bodies[0]
-        ? data.podcast_program_by_pk.podcast_program_bodies[0].description || ''
+      id: data?.podcast_program_by_pk?.id,
+      title: data?.podcast_program_by_pk?.title || '',
+      contentType: data?.podcast_program_by_pk?.content_type || null,
+      filename: data?.podcast_program_by_pk?.filename || null,
+      duration: data?.podcast_program_by_pk?.duration,
+      durationSecond: data?.podcast_program_by_pk?.duration_second,
+      description: data?.podcast_program_by_pk?.podcast_program_bodies[0]
+        ? data?.podcast_program_by_pk?.podcast_program_bodies[0].description || ''
         : '',
-      coverUrl: data.podcast_program_by_pk.cover_url || null,
-      abstract: data.podcast_program_by_pk.abstract || '',
-      listPrice: data.podcast_program_by_pk.list_price,
-      salePrice: data.podcast_program_by_pk.sale_price,
-      soldAt: data.podcast_program_by_pk.sold_at,
-      creatorId: data.podcast_program_by_pk.creator_id,
-      instructors: data.podcast_program_by_pk.podcast_program_roles.map(podcastProgramRole => ({
-        id: podcastProgramRole.member?.id || '',
-        name: podcastProgramRole.member?.name || '',
-        pictureUrl: podcastProgramRole.member?.picture_url || '',
-      })),
-      publishedAt: data.podcast_program_by_pk.published_at ? new Date(data.podcast_program_by_pk.published_at) : null,
-      supportLocales: data.podcast_program_by_pk.support_locales || [],
-      categories: data.podcast_program_by_pk.podcast_program_categories.map(podcastProgramCategory => ({
-        id: podcastProgramCategory.category.id,
-        name: podcastProgramCategory.category.name,
-      })),
-      tags: data.podcast_program_by_pk.podcast_program_tags.map(podcastProgramTag => podcastProgramTag.tag?.name || ''),
-      audios: podcastProgramAudiosFromRawAudios(data.podcast_program_by_pk.podcast_program_audios),
-      isIndividuallySale: data.podcast_program_by_pk.is_individually_sale,
+      coverUrl: data?.podcast_program_by_pk?.cover_url || null,
+      abstract: data?.podcast_program_by_pk?.abstract || '',
+      listPrice: data?.podcast_program_by_pk?.list_price,
+      salePrice: data?.podcast_program_by_pk?.sale_price,
+      soldAt: data?.podcast_program_by_pk?.sold_at,
+      creatorId: data?.podcast_program_by_pk?.creator_id || '',
+      instructors:
+        data?.podcast_program_by_pk?.podcast_program_roles.map(podcastProgramRole => ({
+          id: podcastProgramRole.member?.id || '',
+          name: podcastProgramRole.member?.name || '',
+          pictureUrl: podcastProgramRole.member?.picture_url || '',
+        })) || [],
+      publishedAt: data?.podcast_program_by_pk?.published_at
+        ? new Date(data?.podcast_program_by_pk?.published_at)
+        : null,
+      supportLocales: data?.podcast_program_by_pk?.support_locales || [],
+      categories:
+        data?.podcast_program_by_pk?.podcast_program_categories.map(podcastProgramCategory => ({
+          id: podcastProgramCategory.category.id,
+          name: podcastProgramCategory.category.name,
+        })) || [],
+      tags:
+        data?.podcast_program_by_pk?.podcast_program_tags.map(podcastProgramTag => podcastProgramTag.tag?.name || '') ||
+        [],
+      audios: podcastProgramAudiosFromRawAudios(data?.podcast_program_by_pk?.podcast_program_audios || []) || [],
+      isIndividuallySale: data?.podcast_program_by_pk?.is_individually_sale,
     }
   }, [loading, error, data])
 

--- a/src/pages/PodcastProgramAdminPage.tsx
+++ b/src/pages/PodcastProgramAdminPage.tsx
@@ -1,4 +1,4 @@
-import { Tabs } from 'antd'
+import { Skeleton, Tabs } from 'antd'
 import React, { useEffect } from 'react'
 import { useIntl } from 'react-intl'
 import { useParams } from 'react-router-dom'
@@ -20,11 +20,16 @@ const PodcastProgramAdminPage: React.FC = () => {
   const { formatMessage } = useIntl()
   const { podcastProgramId } = useParams<{ podcastProgramId: string }>()
   const [activeKey, setActiveKey] = useQueryParam('tab', StringParam)
-  const { podcastProgramAdmin, refetchPodcastProgramAdmin } = usePodcastProgramAdmin(podcastProgramId)
+  const { podcastProgramAdmin, refetchPodcastProgramAdmin, loadingPodcastProgramAdmin } =
+    usePodcastProgramAdmin(podcastProgramId)
 
   useEffect(() => {
     refetchPodcastProgramAdmin()
   }, [refetchPodcastProgramAdmin])
+
+  if (loadingPodcastProgramAdmin) {
+    return <Skeleton active />
+  }
 
   return (
     <>

--- a/src/translations/locales/en-us.json
+++ b/src/translations/locales/en-us.json
@@ -1922,6 +1922,7 @@
   "permissionAdmin.ui.createPermissionGroup": "Add permission group",
   "permissionAdmin.ui.deletePermissionGroup": "Delete Permission Group",
   "permissionAdmin.ui.editPermissionGroup": "Edit permission group",
+  "podcast.PodcastProgramPlanForm.notIndividuallySale": "Not individually sale",
   "podcast.label.abstract": "Album Abstract",
   "podcast.label.audioFile": "Audio",
   "podcast.label.description": "Description",

--- a/src/translations/locales/id.json
+++ b/src/translations/locales/id.json
@@ -1922,6 +1922,7 @@
   "permissionAdmin.ui.createPermissionGroup": "Tambahkan grup izin",
   "permissionAdmin.ui.deletePermissionGroup": "Hapus Grup Izin",
   "permissionAdmin.ui.editPermissionGroup": "Edit grup izin",
+  "podcast.PodcastProgramPlanForm.notIndividuallySale": "Not individually sale",
   "podcast.label.abstract": "Album Abstrak",
   "podcast.label.audioFile": "Audio",
   "podcast.label.description": "Deskripsi",

--- a/src/translations/locales/vi.json
+++ b/src/translations/locales/vi.json
@@ -1922,6 +1922,7 @@
   "permissionAdmin.ui.createPermissionGroup": "Nhóm thẩm quyền mới",
   "permissionAdmin.ui.deletePermissionGroup": "Xóa quyền",
   "permissionAdmin.ui.editPermissionGroup": "Chỉnh sửa quyền",
+  "podcast.PodcastProgramPlanForm.notIndividuallySale": "Not individually sale",
   "podcast.label.abstract": " Tóm tắt album ",
   "podcast.label.audioFile": " Âm thanh ",
   "podcast.label.description": "Mô tả",

--- a/src/translations/locales/zh-cn.json
+++ b/src/translations/locales/zh-cn.json
@@ -1922,6 +1922,7 @@
   "permissionAdmin.ui.createPermissionGroup": "新增权限组",
   "permissionAdmin.ui.deletePermissionGroup": "删除权限组",
   "permissionAdmin.ui.editPermissionGroup": "编辑权限组",
+  "podcast.PodcastProgramPlanForm.notIndividuallySale": "无单集销售",
   "podcast.label.abstract": "专辑摘要",
   "podcast.label.audioFile": "音频",
   "podcast.label.description": "内容描述",

--- a/src/translations/locales/zh-tw.json
+++ b/src/translations/locales/zh-tw.json
@@ -1926,6 +1926,7 @@
   "permissionAdmin.ui.createPermissionGroup": "新增權限組",
   "permissionAdmin.ui.deletePermissionGroup": "刪除權限組",
   "permissionAdmin.ui.editPermissionGroup": "編輯權限組",
+  "podcast.PodcastProgramPlanForm.notIndividuallySale": "無單集銷售",
   "podcast.label.abstract": "專輯摘要",
   "podcast.label.audioFile": "音頻",
   "podcast.label.description": "內容描述",

--- a/src/types/podcast.ts
+++ b/src/types/podcast.ts
@@ -18,6 +18,7 @@ export type PodcastProgram = {
   publishedAt: Date | null
   supportLocales: string[]
   audios: PodcastProgramAudio[]
+  isIndividuallySale: boolean
 }
 
 export type PodcastProgramAdminProps = PodcastProgram

--- a/src/types/podcast.ts
+++ b/src/types/podcast.ts
@@ -18,7 +18,7 @@ export type PodcastProgram = {
   publishedAt: Date | null
   supportLocales: string[]
   audios: PodcastProgramAudio[]
-  isIndividuallySale: boolean
+  isIndividuallySale?: boolean
 }
 
 export type PodcastProgramAdminProps = PodcastProgram


### PR DESCRIPTION
- add not individually sale checkbox in PodcastProgramPlanForm

requirement:
在銷售方案的頁面上，希望可以勾選「無單集銷售」；勾選後，底下「定價」與「優惠價」區域可以直接 display: none; 。
https://samplepage.kolable.app/admin/podcast-programs/7fe131c1-6db6-4e61-acc6-c9313d88c24d?tab=plan