### PR TITLE
fix: can't delete category

### DIFF
--- a/src/components/admin/CategoryAdminCard.tsx
+++ b/src/components/admin/CategoryAdminCard.tsx
@@ -147,6 +147,11 @@ const DELETE_CATEGORY = gql`
     delete_voucher_category(where: { category_id: { _eq: $categoryId } }) {
       affected_rows
     }
+    update_member_task(where: { category_id: { _eq: $categoryId } }, _set: { category_id: null }) {
+      returning {
+        id
+      }
+    }
     delete_category(where: { id: { _eq: $categoryId } }) {
       affected_rows
     }

--- a/src/components/admin/CategoryAdminCard.tsx
+++ b/src/components/admin/CategoryAdminCard.tsx
@@ -1,7 +1,6 @@
 import { PlusOutlined } from '@ant-design/icons'
-import { useMutation } from '@apollo/client'
+import { gql, useMutation } from '@apollo/client'
 import { Button, Typography } from 'antd'
-import { gql } from '@apollo/client'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
@@ -115,6 +114,39 @@ const UPDATE_CATEGORY_POSITION = gql`
 `
 const DELETE_CATEGORY = gql`
   mutation DELETE_CATEGORY($categoryId: String!) {
+    delete_program_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_project_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_podcast_program_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_podcast_album_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_activity_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_post_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_merchandise_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_program_package_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_member_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_creator_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
+    delete_voucher_category(where: { category_id: { _eq: $categoryId } }) {
+      affected_rows
+    }
     delete_category(where: { id: { _eq: $categoryId } }) {
       affected_rows
     }

--- a/src/helpers/translation.ts
+++ b/src/helpers/translation.ts
@@ -315,7 +315,7 @@ export const commonMessages = {
     },
     deleteCategoryNotation: {
       id: 'common.text.deleteCategoryNotation',
-      defaultMessage: '確定要刪除此類別？此動作無法復原',
+      defaultMessage: '刪除後會直接移除曾掛此項目的分類，確定要刪除嗎？',
     },
     deletePropertyNotation: {
       id: 'common.text.deletePropertyNotation',

--- a/src/translations/locales/zh-cn.json
+++ b/src/translations/locales/zh-cn.json
@@ -841,7 +841,7 @@
   "common.text.cancelSubscriptionTitle": "确定要取消订阅吗?",
   "common.text.checkEmailNotation": "请至信箱收信更换密码",
   "common.text.copiedToClipboard": "已复制到剪贴簿",
-  "common.text.deleteCategoryNotation": "确定要删除此类别？此动作无法复原",
+  "common.text.deleteCategoryNotation": "删除后会直接移除曾挂此项目的分类，确定要删除吗？",
   "common.text.deletePropertyNotation": "确定要删除此栏位？此动作无法复原",
   "common.text.dueDate": "{date} 到期",
   "common.text.emailNotReceived": "收不到信？",

--- a/src/translations/locales/zh-tw.json
+++ b/src/translations/locales/zh-tw.json
@@ -841,7 +841,7 @@
   "common.text.cancelSubscriptionTitle": "確定要取消訂閱嗎?",
   "common.text.checkEmailNotation": "請至信箱收信更換密碼",
   "common.text.copiedToClipboard": "已複製到剪貼簿",
-  "common.text.deleteCategoryNotation": "確定要刪除此類別？此動作無法復原",
+  "common.text.deleteCategoryNotation": "刪除後會直接移除曾掛此項目的分類，確定要刪除嗎？",
   "common.text.deletePropertyNotation": "確定要刪除此欄位？此動作無法復原",
   "common.text.dueDate": "{date} 到期",
   "common.text.emailNotReceived": "收不到信？",


### PR DESCRIPTION
需求

問題：如果"課程分類"有被掛入到課程中，會無法直接刪除課程分類，出現錯誤訊息，有許多用戶看到錯誤訊息不知道代表什麼意思，希望這邊可以做相關翻譯

錯誤訊息：GraphQL error: Foreign key violation. update or delete on table "category" violates foreign key constraint "program_category_category_id_fkey" on table "program_category"

demo測試：https://demo.lodestar-dev.cc/admin/program-category

進到這個頁面，刪除「不能直接刪除唷～」分類，即可重現

因此：

遇到客戶從後台把課程刪除（系統上是封存）
然後要把分類清空
因為被封存的課程還掛上分類的關係，所以刪不掉分類
(1)
希望可以直接改成：刪除分類時，就把課程上掛的分類也清掉，讓分類能順利清空
部落格、活動、專案...等也都是一樣的問題

(2)
清除時希望能跳警示告知
文案：
刪除後會直接移除曾掛此項目的課程分類，確定要刪除嗎？
[取消] [刪除]

→ 建議所有產品的分類都檢查一輪～～