### PR TITLE
fix: modify close site logic

### DIFF
--- a/src/components/common/AdminRouter.tsx
+++ b/src/components/common/AdminRouter.tsx
@@ -619,7 +619,7 @@ const AdminRouter: React.VFC<{ extraRouteProps: { [routeKey: string]: RouteProps
   const { options: appOptions } = useApp()
   const { isAuthenticating, permissions } = useAuth()
   routesMap = { ...routesMap, ...extraRouteProps }
-  const hasPassedCloseSiteTime = appOptions.close_site_at
+  const hasPassedCloseSiteTime = appOptions?.close_site_at
     ? dayjs(appOptions.close_site_at).diff(dayjs(), 'day') <= 0
     : false
 

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -1399,7 +1399,7 @@ export const useAppUsage = (dateRange: RangeValue<Moment>) => {
 
 export const useAppPlan = () => {
   const { appPlanId } = useApp()
-  const { data } = useQuery<hasura.GetAppPlan, hasura.GetAppPlanVariables>(
+  const { data, loading } = useQuery<hasura.GetAppPlan, hasura.GetAppPlanVariables>(
     gql`
       query GetAppPlan($appPlanId: String!) {
         app_plan_by_pk(id: $appPlanId) {
@@ -1420,20 +1420,36 @@ export const useAppPlan = () => {
   const streaming = data?.app_plan_by_pk?.options?.limit?.streaming
   const usage = data?.app_plan_by_pk?.options?.limit?.usage
 
-  return {
-    appPlan: {
-      id: data?.app_plan_by_pk?.id,
-      name: data?.app_plan_by_pk?.name,
-      options: {
-        maxVideoDuration: storage?.max_video_duration,
-        maxVideoDurationUnit: storage?.max_video_duration_unit,
-        maxOther: storage?.max_other,
-        maxOtherUnit: storage?.max_other_unit,
-        maxVideoWatch: streaming?.max_video_watch,
-        maxVideoWatchUnit: streaming?.max_video_watch_unit,
-        maxSms: usage?.max_sms,
-        maxSmsUnit: usage?.max_sms_unit,
-      },
+  const appPlan: {
+    id?: string
+    name?: string
+    options: {
+      maxVideoDuration: number
+      maxVideoDurationUnit: string
+      maxOther: number
+      maxOtherUnit: string
+      maxVideoWatch: number
+      maxVideoWatchUnit: string
+      maxSms: number
+      maxSmsUnit: string
+    }
+  } = {
+    id: data?.app_plan_by_pk?.id,
+    name: data?.app_plan_by_pk?.name,
+    options: {
+      maxVideoDuration: storage?.max_video_duration || 0,
+      maxVideoDurationUnit: storage?.max_video_duration_unit || 'minute',
+      maxOther: storage?.max_other || 0,
+      maxOtherUnit: storage?.max_other_unit || 'GB',
+      maxVideoWatch: streaming?.max_video_watch || 0,
+      maxVideoWatchUnit: streaming?.max_video_watch_unit || 'minute',
+      maxSms: usage?.max_sms || 0,
+      maxSmsUnit: usage?.max_sms_unit || 'letter',
     },
+  }
+
+  return {
+    appPlan: appPlan,
+    appPlanLoading: loading,
   }
 }

--- a/src/pages/DeactivatePage.tsx
+++ b/src/pages/DeactivatePage.tsx
@@ -1,14 +1,17 @@
 import { Skeleton } from 'antd'
 import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import moment from 'moment'
 import React from 'react'
 import { useIntl } from 'react-intl'
 import { Redirect } from 'react-router'
 import styled from 'styled-components'
-import { useAppUsage } from '../hooks/data'
+import { useAppPlan, useAppUsage } from '../hooks/data'
 import { ErrorBrowserIcon } from '../images/icon'
 import pageMessages from './translation'
+
+dayjs.extend(utc)
 
 const StyledLayout = styled.div`
   display: flex;
@@ -51,16 +54,21 @@ const StyledDeactivateDescription = styled.div`
 const DeactivatePage = () => {
   const { formatMessage } = useIntl()
   const { loading, options: appOptions, endedAt: appEndedAt } = useApp()
+  const { appPlan, appPlanLoading } = useAppPlan()
   const { totalVideoDuration, totalWatchedSeconds } = useAppUsage([moment().startOf('M'), moment().endOf('M')])
   const isSiteContractExpired = dayjs(appEndedAt).diff(dayjs(), 'day') <= 0
-  const isVideoDurationExceedsUsage = Math.round(totalVideoDuration / 60) > appOptions.video_duration
-  const isWatchedSecondsExceedsUsage = totalWatchedSeconds > appOptions.video_duration
+  const isVideoDurationExceedsUsage =
+    (appPlan.options.maxVideoDurationUnit === 'minute' ? Math.round(totalVideoDuration / 60) : totalVideoDuration) >
+    appPlan.options.maxVideoDuration
+  const isWatchedSecondsExceedsUsage =
+    (appPlan.options.maxVideoDurationUnit === 'minute' ? Math.round(totalWatchedSeconds / 60) : totalWatchedSeconds) >
+    appPlan.options.maxVideoWatch
 
-  if (loading) {
+  if (loading || appPlanLoading) {
     return <Skeleton active />
   }
 
-  if (!appOptions.close_site_at || dayjs(appOptions.close_site_at).diff(dayjs(), 'day') >= 0) {
+  if (!appOptions?.close_site_at || dayjs(appOptions?.close_site_at).diff(dayjs(), 'day') >= 0) {
     return <Redirect to="/" />
   }
 


### PR DESCRIPTION
## 需求

因應欄位調整，故儲存流量蓋版程式碼需要進行調整

---

儲存流量的部份因為欄位有調整，所以要改動程式碼，目前的流量限制需要抓 app_plan 的 options 中的值，目前每個客戶的 app_plan_id 已設定完成，就差儲存流量限制已到的蓋版程式碼需要調整，方可上線

另外也請注意，目前只有「影片儲存量」以及「影片觀看流量」這兩個限制，options 中的 sms 跟 max_other 是因應合約規格先設定好的，目前沒有 table 記錄這件事，所以請先略過，「影片儲存量」以及「影片觀看流量」這兩個流量使用請看 app_usage，值都是「秒」，app_plan 的 options 紀錄的數值是「分鐘」，所以請記得正確計算

以上，跟程式碼、資料庫相關有不太理解的地方可以再問 Lois

當初跟 RD 討論 options 的訊息連結：https://discord.com/channels/753127151578120273/1113247074088144998/1133407233582047324

by Lois

## 實作

1. 將原本拿取 maxVideoDuration 和 maxVideoWatch 從 「app 的 option」變成「app_plan 的 option」

2. 在使用 dayjs 的元件補上「dayjs.extend(utc)」

3. 將 appPlan 加上型別