### PR TITLE
fix: modify SalesPerformancePage

### DIFF
--- a/src/components/form/translation.ts
+++ b/src/components/form/translation.ts
@@ -44,7 +44,10 @@ const formMessages = {
     SALES_RECORDS_NORMAL: { id: 'form.PermissionGroup.SALES_RECORDS_NORMAL', defaultMessage: '查看個人銷售紀錄' },
     GROSS_SALES_ADMIN: { id: 'form.PermissionGroup.GROSS_SALES_ADMIN', defaultMessage: '查看所有銷售總額' },
     SALES_RECORDS_DETAILS: { id: 'form.PermissionGroup.SALES_RECORDS_DETAILS', defaultMessage: '查看消費者細項' },
-    MODIFY_MEMBER_ORDER_EQUITY: { id: 'form.PermissionGroup.MODIFY_MEMBER_ORDER_EQUITY', defaultMessage: '調整會員訂單權益功能' },
+    MODIFY_MEMBER_ORDER_EQUITY: {
+      id: 'form.PermissionGroup.MODIFY_MEMBER_ORDER_EQUITY',
+      defaultMessage: '調整會員訂單權益功能',
+    },
 
     // program
     PROGRAM_ADMIN: { id: 'form.PermissionGroup.PROGRAM_ADMIN', defaultMessage: '所有課程管理功能' },
@@ -286,7 +289,11 @@ const formMessages = {
     ANALYSIS_ADMIN: { id: 'form.PermissionGroup.ANALYSIS_ADMIN', defaultMessage: '所有數據分析功能' },
 
     // sales
-    SALES_PERFORMANCE_ADMIN: { id: 'form.PermissionGroup.SALES_PERFORMANCE_ADMIN', defaultMessage: '業績總表' },
+    SALES_PERFORMANCE_ADMIN: { id: 'form.PermissionGroup.SALES_PERFORMANCE_ADMIN', defaultMessage: '查看所有業績' },
+    SALES_SAME_DEPARTMENT_PERFORMANCE_ADMIN: {
+      id: 'form.PermissionGroup.SALES_VIEW_SAME_DEPARTMENT_PERFORMANCE_ADMIN',
+      defaultMessage: '查看同機構業績',
+    },
 
     // sales_lead
     SALES_LEAD_ADMIN: { id: 'form.PermissionGroup.SALES_LEAD_ADMIN', defaultMessage: '所有名單撥打功能' },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12642,7 +12642,7 @@ lodash.upperfirst@^4.3.1:
 
 lodestar-app-element@urfit-tech/lodestar-app-element#master:
   version "0.1.0"
-  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/bb3ec3bab26c565828d74b46fa96c66c49f4e49c"
+  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/6620227b48425d7d86f21647f2e794829e0d68bc"
   dependencies:
     "@apollo/client" "^3.7.11"
     "@bobthered/tailwindcss-palette-generator" "2.0.0"


### PR DESCRIPTION
## 測試

https://demo.lodestar-dev.cc/admin/sales/performance

## 需求

先前有申請過 [機構]不得看到其他人，讓機構之間不得看到彼此業績
但好像沒有留哪一個機構是可以看的到所有人的

需要切一個權限選項為「查看所有業績」放置在業務管理底下[image.png](https://trello.com/1/cards/64e87d6d359e302e5df41a28/attachments/64e87da214fea8371680bce0/download/image.png)

新增「查看所有業績」權限選項

原「業績總表」改詞為「查看同機構業績」-->再改之前，先幫幫確認是否確實現在邏輯是無法看到不同機構業績 → 未調前可以看到其他機構

https://app.hubspot.com/contacts/41219621/record/0-5/1854983332

## 實作

1. 在 Hasura 新增「SALES_VIEW_SAME_DEPARTMENT_PERFORMANCE_ADMIN」的「查看同機構業績」，並將「SALES_PERFORMANCE_ADMIN」名稱改名為「查看所有業績」

2. 調整「member」和「order_executor」的 select 權限判斷

3. 調整業務總表頁面和權限控制