### PR TITLE
Feature/rwd menu dropdown fix

### DIFF
--- a/src/components/attend/AttendButton.tsx
+++ b/src/components/attend/AttendButton.tsx
@@ -1,15 +1,24 @@
 import { Button, message } from 'antd'
 import moment from 'moment'
 import React from 'react'
+import styled from 'styled-components'
 import { handleError } from '../../helpers'
 import { useAttend, useGetAttend } from '../../hooks/attend'
+
+const NavbarClockButton = styled(Button)`
+  @media screen and (max-width: 480px) {
+    padding: 5px 10px;
+    margin: 0px 0px;
+    font-size: 15px;
+  }
+`
 
 const AttendButton: React.FC<{ memberId: string }> = ({ memberId }) => {
   const { attend, refetchAttend } = useGetAttend(memberId)
   const { insertAttend, updateAttend } = useAttend()
 
   return (
-    <Button
+    <NavbarClockButton
       className="mr-3"
       type="primary"
       onClick={
@@ -41,7 +50,7 @@ const AttendButton: React.FC<{ memberId: string }> = ({ memberId }) => {
       }}
     >
       {attend.length !== 0 ? '下班打卡' : '上班打卡'}
-    </Button>
+    </NavbarClockButton>
   )
 }
 export default AttendButton

--- a/src/components/common/MemberProfileButton.tsx
+++ b/src/components/common/MemberProfileButton.tsx
@@ -79,7 +79,7 @@ const MemberProfileButton: React.FC<{ memberId: string }> = ({ memberId }) => {
 
         <Responsive.Default>
           <BorderedItem className="shift-left">
-            <AdminMenu />
+            <AdminMenu opened={true} />
           </BorderedItem>
         </Responsive.Default>
 

--- a/src/components/common/MemberProfileButton.tsx
+++ b/src/components/common/MemberProfileButton.tsx
@@ -41,6 +41,13 @@ const BorderedItem = styled(List.Item)`
   }
 `
 
+const MenuButtonStyle = styled(Button)`
+  @media screen and (max-width: 480px) {
+    padding: 18px 5px;
+    width: 24px;
+  }
+`
+
 const MemberProfileButton: React.FC<{ memberId: string }> = ({ memberId }) => {
   const { formatMessage } = useIntl()
   const history = useHistory()
@@ -88,7 +95,7 @@ const MemberProfileButton: React.FC<{ memberId: string }> = ({ memberId }) => {
     <>
       <Responsive.Default>
         <Popover placement="bottomRight" trigger="click" content={content} className="ml-2">
-          <Button type="link" icon={<MenuOutlined />} />
+          <MenuButtonStyle type="link" icon={<MenuOutlined />} />
         </Popover>
       </Responsive.Default>
       <Responsive.Desktop>
@@ -114,7 +121,7 @@ const MemberProfileButton: React.FC<{ memberId: string }> = ({ memberId }) => {
             </Wrapper>
           }
         >
-          <Button type="link" icon={<MenuOutlined />} />
+          <MenuButtonStyle type="link" icon={<MenuOutlined />} />
         </Popover>
       </Responsive.Default>
 

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -39,8 +39,6 @@ const AdminLayout: React.FC = ({ children }) => {
       noFooter
       renderTitle={() => (
         <Link to={`/`} className="d-flex">
-          {/* TODO */}
-
           <NavbarBackStageButton type="link">{formatMessage(commonMessages.ui.backstage)}</NavbarBackStageButton>
         </Link>
       )}

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -8,7 +8,7 @@ import { StyledContent } from '.'
 import { commonMessages } from '../../helpers/translation'
 import AdminMenu from '../admin/AdminMenu'
 import { useRouteKeys } from '../common/AdminRouter'
-import Responsive from '../common/Responsive'
+import Responsive, { BREAK_POINT } from '../common/Responsive'
 import DefaultLayout from './DefaultLayout'
 
 const SettingBlockToggleButton = styled(Button)<{ variant?: 'opened' | 'unopened' }>`
@@ -17,6 +17,10 @@ const SettingBlockToggleButton = styled(Button)<{ variant?: 'opened' | 'unopened
   left: ${props => (props.variant === 'unopened' ? '0px' : '240px')};
   border: 1px solid var(--gray);
   border-left: none;
+
+  @media (max-width: ${BREAK_POINT}px) {
+    display: none;
+  }
 `
 
 const NavbarBackStageButton = styled(Button)`

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -8,19 +8,14 @@ import { StyledContent } from '.'
 import { commonMessages } from '../../helpers/translation'
 import AdminMenu from '../admin/AdminMenu'
 import { useRouteKeys } from '../common/AdminRouter'
-import Responsive, { BREAK_POINT } from '../common/Responsive'
+import Responsive from '../common/Responsive'
 import DefaultLayout from './DefaultLayout'
 
 const SettingBlockToggleButton = styled(Button)<{ variant?: 'opened' | 'unopened' }>`
-  position: absolute;
+  position: relative;
   bottom: 0%;
-  left: ${props => (props.variant === 'unopened' ? '0px' : '240px')};
   border: 1px solid var(--gray);
   border-left: none;
-
-  @media (max-width: ${BREAK_POINT}px) {
-    display: none;
-  }
 `
 
 const NavbarBackStageButton = styled(Button)`
@@ -43,14 +38,17 @@ const AdminLayout: React.FC = ({ children }) => {
         </Link>
       )}
     >
-      <SettingBlockToggleButton onClick={() => setOpen(!open)} variant={open ? 'opened' : 'unopened'}>
-        {open ? <LeftOutlined /> : <RightOutlined />}
-      </SettingBlockToggleButton>
       <div className="d-flex">
         <Responsive.Desktop>
-          <StyledContent noFooter white variant={open ? 'opened' : 'unopened'}>
-            <AdminMenu defaultSelectedKeys={defaultSelectedKeys} opened={open} />
-          </StyledContent>
+          <div className="d-flex align-items-end">
+            <StyledContent noFooter white variant={open ? 'opened' : 'unopened'}>
+              <AdminMenu defaultSelectedKeys={defaultSelectedKeys} opened={open} />
+            </StyledContent>
+
+            <SettingBlockToggleButton onClick={() => setOpen(!open)}>
+              {open ? <LeftOutlined /> : <RightOutlined />}
+            </SettingBlockToggleButton>
+          </div>
         </Responsive.Desktop>
 
         <StyledContent className="flex-grow-1 p-3 p-sm-5" noFooter>

--- a/src/components/layout/AdminLayout.tsx
+++ b/src/components/layout/AdminLayout.tsx
@@ -19,6 +19,13 @@ const SettingBlockToggleButton = styled(Button)<{ variant?: 'opened' | 'unopened
   border-left: none;
 `
 
+const NavbarBackStageButton = styled(Button)`
+  @media screen and (max-width: 480px) {
+    font-size: 15px;
+    padding: 5px 5px;
+  }
+`
+
 const AdminLayout: React.FC = ({ children }) => {
   const { formatMessage } = useIntl()
   const defaultSelectedKeys = useRouteKeys()
@@ -28,7 +35,9 @@ const AdminLayout: React.FC = ({ children }) => {
       noFooter
       renderTitle={() => (
         <Link to={`/`} className="d-flex">
-          <Button type="link">{formatMessage(commonMessages.ui.backstage)}</Button>
+          {/* TODO */}
+
+          <NavbarBackStageButton type="link">{formatMessage(commonMessages.ui.backstage)}</NavbarBackStageButton>
         </Link>
       )}
     >

--- a/src/components/notification/NotificationDropdown.tsx
+++ b/src/components/notification/NotificationDropdown.tsx
@@ -1,7 +1,6 @@
 import { BellOutlined } from '@ant-design/icons'
-import { useMutation } from '@apollo/client'
+import { gql, useMutation } from '@apollo/client'
 import { Badge, Button, List, Popover } from 'antd'
-import { gql } from '@apollo/client'
 import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
@@ -33,6 +32,11 @@ const StyledBadgeWrapper = styled.div`
     top: 8px;
     right: 4px;
   }
+
+  @media screen and (max-width: 480px) {
+    width: 29.85px;
+    font-size: 50%;
+  }
 `
 const StyledButton = styled(Button)`
   font-size: 20px;
@@ -41,6 +45,10 @@ const StyledButton = styled(Button)`
   &&:active,
   &&:focus {
     color: var(--gray-darker);
+  }
+
+  @media screen and (max-width: 480px) {
+    width: 29.85px;
   }
 `
 const StyledReadAllButton = styled(Button)`


### PR DESCRIPTION
- 恢復漢堡 menu 功能選單恢復
  - <img width="353" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107536598/6f09e40f-ac39-4704-be2f-faac07b823f0">

- 手機版 navbar 跑版修復
  -  <img width="492" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107536598/852dde22-1c5a-4edd-bc0a-10facd217b08">
  
 - 左側 menu 手機版的收合按鈕要 disable
   -  <img width="477" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107536598/be25183a-818c-4360-8ed9-349fce3257b0">

