### PR TITLE
feat: Merge consecutive content logs and process start and end times

### DIFF
--- a/src/pages/MemberAdminPage/MemberHistoryAdminBlock.tsx
+++ b/src/pages/MemberAdminPage/MemberHistoryAdminBlock.tsx
@@ -1,6 +1,5 @@
-import { useQuery } from '@apollo/client'
+import { gql, useQuery } from '@apollo/client'
 import { Breadcrumb, DatePicker, Slider, Timeline } from 'antd'
-import { gql } from '@apollo/client'
 import moment, { Moment } from 'moment'
 import { RangeValue } from 'rc-picker/lib/interface'
 import React, { useState } from 'react'
@@ -16,7 +15,37 @@ const MemberHistoryAdminBlock: React.VFC<{ memberId: string }> = ({ memberId }) 
       endedAt: dateRange?.[1],
     },
   })
-  const logs = data?.program_content_log.filter(v => v.ended_at - v.started_at > 1) || []
+
+  const isValidLog = (log: ProgramContentLog) => log.ended_at - log.started_at > 1
+
+  // sort Logs desc first
+  const sortedLogs = (data?.program_content_log || [])
+    .filter(isValidLog)
+    .sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+
+  type ProgramContentLog = hasura.GET_HISTORY['program_content_log'][number]
+
+  const mergedLogs = sortedLogs
+    .reduce<ProgramContentLog[]>((accumulatedLogs, currentLog) => {
+      const lastLog = accumulatedLogs[accumulatedLogs.length - 1]
+
+      if (lastLog && lastLog.program_content.id === currentLog.program_content.id) {
+        // Merge consecutive logs with the same program_content ID.
+        // Update the last log to have the earliest 'started_at' and the latest 'ended_at'.
+        const updatedLog = {
+          ...lastLog,
+          started_at: Math.min(lastLog.started_at, currentLog.started_at),
+          ended_at: Math.max(lastLog.ended_at, currentLog.ended_at),
+        }
+        accumulatedLogs[accumulatedLogs.length - 1] = updatedLog
+      } else {
+        // If not consecutive, add the current log as a new entry.
+        accumulatedLogs.push({ ...currentLog })
+      }
+      return accumulatedLogs
+    }, [])
+    .filter(isValidLog)
+
   return (
     <>
       <DatePicker.RangePicker
@@ -31,11 +60,11 @@ const MemberHistoryAdminBlock: React.VFC<{ memberId: string }> = ({ memberId }) 
         onChange={dates => setDateRange(dates)}
       />
       <AdminBlock>
-        {!loading && logs.length === 0 ? (
+        {!loading && mergedLogs.length === 0 ? (
           <div>No history.</div>
         ) : (
           <Timeline pending={loading ? 'Loading...' : null}>
-            {logs.map(v => (
+            {mergedLogs.map(v => (
               <Timeline.Item key={v.id}>
                 <span className="mr-2">{moment(v.created_at).format('MM-DD HH:mm')}</span>
                 <div className="row">
@@ -69,12 +98,16 @@ const MemberHistoryAdminBlock: React.VFC<{ memberId: string }> = ({ memberId }) 
                         </a>
                       </Breadcrumb.Item>
                     </Breadcrumb>
-                    <div>{Math.round(((v.ended_at - v.started_at) / v.program_content.duration) * 100)}% watched</div>
+                    <div>
+                      {v.program_content.duration > 0
+                        ? `${Math.round(((v.ended_at - v.started_at) / v.program_content.duration) * 100)}% watched`
+                        : '0% watched'}
+                    </div>
                   </div>
                   <div className="col-12 col-lg-6">
                     <Slider
                       range
-                      max={v.program_content.duration}
+                      max={Math.round(v.program_content.duration)}
                       defaultValue={[v.started_at, v.ended_at]}
                       disabled
                       tipFormatter={v => v && new Date(v * 1000).toISOString().substr(11, 8)}

--- a/src/translations/locales/zh-tw.json
+++ b/src/translations/locales/zh-tw.json
@@ -1663,6 +1663,7 @@
   "member.ui.switchTable": "切換列表模式",
   "member.ui.newTask":"新增待辦",
   "member.ui.editTask":"編輯待辦",
+  "member.ui.memberPage": "學員主頁",
   "member.status.priorityHigh":"High",
   "member.status.priorityMedium":"Medium",
   "member.status.priorityLow":"Low",


### PR DESCRIPTION
## 描述

### 問題背景
由於 `program_content_log` 每五秒記錄一次用戶活動，因此連續觀看的情況下前端會出現多筆紀錄。例如，如果使用者持續觀看了 15 秒的內容，前端會出現三筆紀錄。這在 UI 上顯示為多筆短暫的歷程紀錄，而不是一筆連續的觀看歷程。

## 目標
希望使用者歷史紀錄能夠顯示出如持續觀看 10 分鐘這樣的連續歷史紀錄。

### 解決方法

1. **過濾有效的紀錄**：通過 `isValidLog` 函數過濾出那些 `ended_at` 和 `started_at` 差異超過 1 秒的紀錄

2. **降序排序紀錄**：對紀錄按照 `created_at` 欄位進行降序排序，確保處理是從最新到最舊的

3. **合併連續的紀錄**：使用 `reduce` 函數合併具有相同 `program_content` ID 的連續日誌。對於每一組連續日誌，計算最早的 `started_at` 和最晚的 `ended_at`，這樣可以將多筆短暫的歷史紀錄合併為一筆較長的歷史紀錄

### 額外處理
1. 處理分母為0的情況
```
 {v.program_content.duration > 0
                        ? `${Math.round(((v.ended_at - v.started_at) / v.program_content.duration) * 100)}% watched`
                        : '0% watched'}
```
2. max={Math.round(v.program_content.duration)}
   - 因為 `v.program_content.duration` 有可能不是整數
   - 確保該值為整數