### PR TITLE
Feature/move activity to lodestar server

### DIFF
--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -70,22 +70,18 @@ const ActivityCollectionTabs: React.FC<{
       scenario: currentTab,
     }
   }, [currentTab, memberId, appId])
-  // 'Holding' | 'Finished' | 'Draft' | 'PrivateHolding'
 
   const basicCondition = useMemo(() => {
     return adminCondition
   }, [adminCondition])
 
-  const { loadingActivities, activities, currentTabActivityCount, loadMoreActivities } = useActivityCollection(
-    basicCondition,
-    selectedCategoryId,
-  )
+  const { loadingActivities, activities, currentTabActivityCount, loadMoreActivities, showLoadMoreButton } =
+    useActivityCollection(basicCondition, selectedCategoryId)
   const { categories } = useCategoryCollection(condition[currentTab])
 
   useEffect(() => {
     if (!loadingActivities && currentTabActivityCount !== undefined) {
       setCounts(prevCounts => {
-        console.log('prevCounts', prevCounts)
         return {
           ...prevCounts,
           [currentTab]: currentTabActivityCount,
@@ -169,7 +165,7 @@ const ActivityCollectionTabs: React.FC<{
                 ))
               )}
             </div>
-            {loadMoreActivities && (
+            {showLoadMoreButton && (
               <div className="text-center mt-4">
                 <Button
                   loading={loading}

--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -58,6 +58,7 @@ const ActivityCollectionTabs: React.FC<{
       activity_during_period: { ended_at: { _gt: 'now()' } },
     },
   }
+  const { loading, id: appId, enabledModules, settings } = useApp()
 
   const adminCondition = {
     holding: {
@@ -65,21 +66,25 @@ const ActivityCollectionTabs: React.FC<{
       isPrivate: false,
       publishedAtNotNull: true,
       activityEndedAfterNow: true,
+      appId: appId,
     },
     finished: {
       organizerId: memberId,
       publishedAtNotNull: true,
       activityEndedBeforeNow: true,
+      appId: appId,
     },
     draft: {
       organizerId: memberId,
       publishedAtIsNull: true,
       activityEndedIsNull: true,
+      appId: appId,
     },
     privateHolding: {
       organizerId: memberId,
       isPrivate: true,
       activityEndedAfterNow: true,
+      appId: appId,
     },
   }
 

--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -1,6 +1,6 @@
 import { Button, Skeleton, Tabs } from 'antd'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
-import React, { useState } from 'react'
+import React, { useMemo, useState } from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import styled from 'styled-components'
 import { commonMessages } from '../../helpers/translation'
@@ -58,8 +58,39 @@ const ActivityCollectionTabs: React.FC<{
       activity_during_period: { ended_at: { _gt: 'now()' } },
     },
   }
+
+  const adminCondition = {
+    holding: {
+      organizerId: memberId,
+      isPrivate: false,
+      publishedAtNotNull: true,
+      activityEndedAfterNow: true,
+    },
+    finished: {
+      organizerId: memberId,
+      publishedAtNotNull: true,
+      activityEndedBeforeNow: true,
+    },
+    draft: {
+      organizerId: memberId,
+      publishedAtIsNull: true,
+      activityEndedIsNull: true,
+    },
+    privateHolding: {
+      organizerId: memberId,
+      isPrivate: true,
+      activityEndedAfterNow: true,
+    },
+  }
+
+  const basicCondition = useMemo(() => {
+    return {
+      ...adminCondition[currentTab],
+    }
+  }, [currentTab, memberId])
+
   const { loadingActivities, activities, currentTabActivityCount, loadMoreActivities } = useActivityCollection(
-    condition[currentTab],
+    basicCondition,
     selectedCategoryId,
   )
   const { categories } = useCategoryCollection(condition[currentTab])
@@ -126,20 +157,23 @@ const ActivityCollectionTabs: React.FC<{
               ))}
             </>
             <div className="row py-5">
-              {loadingActivities && <Skeleton active />}
-              {activities.map(activity => (
-                <div key={activity.id} className="col-12 col-md-6 col-lg-4 mb-5">
-                  <Activity
-                    id={activity.id}
-                    coverUrl={activity.coverUrl}
-                    title={activity.title}
-                    includeSessionTypes={activity.includeSessionTypes}
-                    participantsCount={activity.participantsCount}
-                    startedAt={activity.startedAt}
-                    endedAt={activity.endedAt}
-                  />
-                </div>
-              ))}
+              {loadingActivities ? (
+                <Skeleton active />
+              ) : (
+                activities.map(activity => (
+                  <div key={activity.id} className="col-12 col-md-6 col-lg-4 mb-5">
+                    <Activity
+                      id={activity.id}
+                      coverUrl={activity.coverUrl}
+                      title={activity.title}
+                      includeSessionTypes={activity.includeSessionTypes}
+                      participantsCount={activity.participantsCount}
+                      startedAt={activity.startedAt}
+                      endedAt={activity.endedAt}
+                    />
+                  </div>
+                ))
+              )}
             </div>
             {loadMoreActivities && (
               <div className="text-center mt-4">

--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -4,7 +4,8 @@ import React, { useState } from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import styled from 'styled-components'
 import { commonMessages } from '../../helpers/translation'
-import { useActivityCollection, useCategoryCollection } from '../../hooks/activity'
+import { useCategoryCollection } from '../../hooks/activity'
+import useActivityCollection from '../../hooks/activity/useActivityCollection'
 import Activity from './Activity'
 
 const StyledButton = styled(Button)`
@@ -145,8 +146,8 @@ const ActivityCollectionTabs: React.FC<{
                 <Button
                   loading={loading}
                   onClick={() => {
-                    setLoading(true)
-                    loadMoreActivities().then(() => setLoading(false))
+                    // setLoading(true)
+                    loadMoreActivities()
                   }}
                 >
                   {formatMessage(commonMessages.ui.showMore)}

--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -76,8 +76,10 @@ const ActivityCollectionTabs: React.FC<{
     return adminCondition
   }, [adminCondition])
 
-  const { loadingActivities, activities, currentTabActivityCount, loadMoreActivities, showLoadMoreButton } =
-    useActivityCollection(basicCondition, selectedCategoryId)
+  const { loadingActivities, activities, currentTabActivityCount, loadMoreActivities } = useActivityCollection(
+    basicCondition,
+    selectedCategoryId,
+  )
   const { categories } = useCategoryCollection(condition[currentTab])
 
   useEffect(() => {

--- a/src/components/activity/ActivityCollectionTabs.tsx
+++ b/src/components/activity/ActivityCollectionTabs.tsx
@@ -36,6 +36,7 @@ const ActivityCollectionTabs: React.FC<{
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null)
   const [loading, setLoading] = useState(false)
   const [counts, setCounts] = useState<{ [key: string]: number }>({})
+
   const condition = {
     holding: {
       organizer_id: { _eq: memberId },
@@ -165,12 +166,13 @@ const ActivityCollectionTabs: React.FC<{
                 ))
               )}
             </div>
-            {showLoadMoreButton && (
+            {loadMoreActivities && (
               <div className="text-center mt-4">
                 <Button
                   loading={loading}
                   onClick={() => {
-                    loadMoreActivities()
+                    setLoading(true)
+                    loadMoreActivities().then(() => setLoading(false))
                   }}
                 >
                   {formatMessage(commonMessages.ui.showMore)}

--- a/src/helpers/translation.ts
+++ b/src/helpers/translation.ts
@@ -573,6 +573,7 @@ export const activityMessages = {
     onlineActivity: { id: 'activity.label.onlineActivity', defaultMessage: '線上活動' },
     offlineActivity: { id: 'activity.label.offlineActivity', defaultMessage: '實體活動' },
     onlineAndOfflineActivity: { id: 'activity.label.allActivity', defaultMessage: '實體 & 線上' },
+    both: { id: 'activity.label.allActivity', defaultMessage: '實體 & 線上' }
   }),
   status: defineMessages({
     public: { id: 'activity.status.public', defaultMessage: '公開' },

--- a/src/hooks/activity/activitiyCollectionType.ts
+++ b/src/hooks/activity/activitiyCollectionType.ts
@@ -1,0 +1,38 @@
+export interface ActivityDisplayProps {
+  id: string;
+  coverUrl: string | null;
+  title: string;
+  publishedAt: Date | null;
+  includeSessionTypes: ('offline' | 'online')[];
+  participantsCount: {
+    online: number;
+    offline: number;
+  };
+  startedAt: Date | null;
+  endedAt: Date | null;
+  isPrivate: boolean;
+  createdAt: Date | null;
+}
+
+export type FetchActivityDisplayProps = Pick<ActivityDisplayProps, 'id' | 'title' | 'coverUrl' | 'includeSessionTypes' | 'participantsCount' | 'isPrivate'> & {
+  publishedAt: string | null;
+  startedAt: string | null;
+  endedAt: string | null;
+  createdAt: string | null;
+}
+
+export type ActivityBasicCondition = {
+  organizerId?: string | null;
+  appId: string;
+  scenario: 'holding' | 'finished' | 'draft' | 'privateHolding';
+};
+
+export interface FetchActivitiesResponse {
+  activities: FetchActivityDisplayProps[];
+  totalCount: number;
+}
+
+export interface ActivityCollectionState {
+  activities: ActivityDisplayProps[];
+  totalCount: number;
+}

--- a/src/hooks/activity/useActivityCollection.ts
+++ b/src/hooks/activity/useActivityCollection.ts
@@ -1,0 +1,126 @@
+import axios from 'axios';
+import { useState, useEffect, useCallback } from 'react';
+import { ActivityAdminProps } from '../../types/activity';
+
+interface ActivityDisplayProps {
+  id: string;
+  coverUrl: string | null;
+  title: string;
+  publishedAt: Date | null;
+  includeSessionTypes: ('offline' | 'online')[];
+  participantsCount: {
+    online: number;
+    offline: number;
+  };
+  startedAt: Date | null;
+  endedAt: Date | null;
+  isPrivate: boolean;
+}
+
+interface BasicCondition {
+}
+
+interface FetchActivitiesResponse {
+  activities: ActivityAdminProps[];
+  totalCount: number;
+}
+
+const fetchActivitiesApi = async (
+  basicCondition: BasicCondition,
+  categoryId: string | null,
+  limit: number,
+  offset: number
+): Promise<FetchActivitiesResponse> => {
+  try {
+    const response = await axios.post<FetchActivitiesResponse>('http://localhost:3000/activity_collection', {
+      basicCondition,
+      categoryId,
+      limit,
+      offset,
+    });
+    console.log(response.data)
+    return response.data;
+  } catch (error) {
+    console.error('Error fetching activities:', error);
+    throw error;
+  }
+};
+
+const useActivityCollection = (
+  basicCondition: BasicCondition,
+  categoryId: string | null
+) => {
+  const [activities, setActivities] = useState<ActivityDisplayProps[]>([]);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+  const [currentTabActivityCount, setCurrentTabActivityCount] = useState<number>(0);
+  const [offset, setOffset] = useState<number>(0);
+
+  const limit = 20;
+
+  const fetchActivities = useCallback(async () => {
+    try {
+      setLoading(true);
+      const data = await fetchActivitiesApi(basicCondition, categoryId, limit, offset);
+      const transformedActivities = data.activities.map(activity => {
+        const onlineCount = activity.tickets.reduce((acc, ticket) => acc + (ticket.enrollmentsCount ?? 0), 0);
+        const offlineCount = activity.sessions.reduce((acc, session) => acc + (session.enrollmentsCount.offline ?? 0), 0);
+        const includeSessionTypes = activity.sessions.flatMap(session => 
+          session.location ? ['offline'] : (session.onlineLink ? ['online'] : [])
+        ).filter((v, i, a) => a.indexOf(v) === i);
+      
+        return {
+          id: activity.id,
+          coverUrl: activity.coverUrl || null,
+          title: activity.title || '',
+          publishedAt: activity.publishedAt ? new Date(activity.publishedAt) : null,
+          isPrivate: activity.isPrivate !== undefined ? activity.isPrivate : false, 
+          participantsCount: {
+            online: onlineCount,
+            offline: offlineCount
+          },
+          includeSessionTypes: includeSessionTypes as ('offline' | 'online')[],
+          startedAt: activity.sessions.length > 0 ? new Date(activity.sessions[0].startedAt) : null,
+          endedAt: activity.sessions.length > 0 ? new Date(activity.sessions[0].endedAt) : null,
+        };
+      });
+      setActivities(prevActivities => {
+        const updatedActivities = [...prevActivities, ...transformedActivities];
+      
+        const activitiesMap = new Map();
+        for (const activity of updatedActivities) {
+          activitiesMap.set(activity.id, activity);
+        }
+      
+        return Array.from(activitiesMap.values());
+      });
+      setCurrentTabActivityCount(data.totalCount);
+    } catch (err) {
+      if (err instanceof Error) {
+        setError(err); 
+      } else {
+        setError(new Error('An unknown error occurred'));
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [categoryId, offset, limit]);
+
+  useEffect(() => {
+    fetchActivities();
+  }, [fetchActivities]);
+
+  const loadMoreActivities = () => {
+    setOffset(prevOffset => prevOffset + limit);
+  };
+
+  return {
+    loadingActivities: loading,
+    errorActivities: error,
+    activities,
+    currentTabActivityCount,
+    loadMoreActivities,
+  };
+};
+
+export default useActivityCollection;

--- a/src/hooks/activity/useActivityCollection.ts
+++ b/src/hooks/activity/useActivityCollection.ts
@@ -1,183 +1,195 @@
-import axios from 'axios';
-import { useState, useEffect, useCallback } from 'react';
+import axios from "axios";
+import { useState, useEffect, useCallback } from "react";
+import {
+  ActivityCollectionState,
+  ActivityDisplayProps,
+  FetchActivityDisplayProps,
+  ActivityBasicCondition,
+  FetchActivitiesResponse,
+} from "./activitiyCollectionType";
+
 enum LoadingState {
   Idle,
   InitialLoading,
   LoadingMore,
-  None
-}
-interface ActivityDisplayProps {
-  id: string;
-  coverUrl: string | null;
-  title: string;
-  publishedAt: Date | null;
-  includeSessionTypes: ('offline' | 'online')[];
-  participantsCount: {
-    online: number;
-    offline: number;
-  };
-  startedAt: Date | null;
-  endedAt: Date | null;
-  isPrivate: boolean;
-  createdAt: Date | null
-}
-
-type FetchActivityDisplayProps = Pick<ActivityDisplayProps, 'id' | 'title' | 'coverUrl' | 'includeSessionTypes' | 'participantsCount' | 'isPrivate'> & {
-  publishedAt: string | null;
-  startedAt: string | null;
-  endedAt: string | null;
-  createdAt: string | null
-}
-
-type ActivityBasicCondition = {
-  organizerId?: string | null;
-  appId: string;
-  scenario: 'holding' | 'finished' | 'draft' | 'privateHolding';
-};
-
-interface FetchActivitiesResponse {
-  activities: FetchActivityDisplayProps[];
-  totalCount: number;
+  None,
 }
 
 const fetchActivitiesApi = (
-  basicCondition: ActivityBasicCondition, 
-  categoryId: string | null, 
-  limit: number, 
-  offset: number
+  basicCondition: ActivityBasicCondition,
+  categoryId: string | null,
+  limit: number,
+  offset: number,
 ) => {
-  return axios.get<FetchActivitiesResponse>(`${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/activity/activity_collection`, {
-    params: {
-      basicCondition,
-      categoryId,
-      limit,
-      offset,
-    }
-  }).then(response => {
-    response.data.activities = response.data.activities || [];
-    return response.data;
-  });
+  return axios
+    .get<FetchActivitiesResponse>(
+      `${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/activity/activity_collection`,
+      {
+        params: {
+          basicCondition,
+          categoryId,
+          limit,
+          offset,
+        },
+      },
+    )
+    .then((response) => {
+      response.data.activities = response.data.activities || [];
+      return response.data;
+    });
 };
 
-const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryId: string | null) => {
-  const [activities, setActivities] = useState<ActivityDisplayProps[]>([]);
-  const [loading, setLoading] = useState<boolean>(false);
+const useActivityCollection = (
+  basicCondition: ActivityBasicCondition,
+  categoryId: string | null,
+) => {
+  const [activityCollection, setActivityCollection] =
+    useState<ActivityCollectionState>({
+      activities: [],
+      totalCount: 0,
+    });
   const [error, setError] = useState<Error | null>(null);
-  const [currentTabActivityCount, setCurrentTabActivityCount] = useState<number>(0);
+  const [currentTabActivityCount, setCurrentTabActivityCount] =
+    useState<number>(0);
   const [offset, setOffset] = useState<number>(0);
-  const [isLoadMore, setIsLoadMore] = useState<boolean>(false);
-  const [showLoadMoreButton , setShowLoadMoreButton] = useState<boolean>(false)
-  const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true); // 新添加的状态变量
-  const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.Idle);
+  const [loadingState, setLoadingState] = useState<LoadingState>(
+    LoadingState.Idle,
+  );
 
   const limit = 20;
 
-  const transformDate = (dateString: string | null): Date | null => 
-  dateString ? new Date(dateString) : null;
+  const transformDate = (dateString: string | null): Date | null =>
+    dateString ? new Date(dateString) : null;
 
-  const transformActivity = (activity: FetchActivityDisplayProps): ActivityDisplayProps => ({
-      ...activity,
-      publishedAt: transformDate(activity.publishedAt),
-      startedAt: transformDate(activity.startedAt),
-      endedAt: transformDate(activity.endedAt),
-      createdAt: transformDate(activity.createdAt),
-  })
+  const transformActivity = (
+    activity: FetchActivityDisplayProps,
+  ): ActivityDisplayProps => ({
+    ...activity,
+    publishedAt: transformDate(activity.publishedAt),
+    startedAt: transformDate(activity.startedAt),
+    endedAt: transformDate(activity.endedAt),
+    createdAt: transformDate(activity.createdAt),
+  });
 
   useEffect(() => {
     setOffset(0);
     setLoadingState(LoadingState.InitialLoading);
   }, [basicCondition, categoryId]);
 
+  const fetchActivities = useCallback(
+    async (isLoadMoreCall = false, newOffset = 0) => {
+      setLoadingState(
+        isLoadMoreCall ? LoadingState.LoadingMore : LoadingState.InitialLoading,
+      );
 
-  const fetchActivities = useCallback(async (isLoadMoreCall = false, newOffset = 0) => {
-    console.log("#R########2")
-    console.log(limit, newOffset)
-    try {
-      const data = await fetchActivitiesApi(basicCondition, categoryId, limit, newOffset);
+      try {
+        const data = await fetchActivitiesApi(
+          basicCondition,
+          categoryId,
+          limit,
+          newOffset,
+        );
 
-      console.log('tranformActivityData', data )
+        const tranformActivityData = data.activities.map(transformActivity);
 
-      const tranformActivityData = data.activities.map(transformActivity)
-    
+        setActivityCollection((prevState) => {
+          let updatedActivities;
 
-      setActivities(prevActivities => {
-        let updatedActivities;
-      
-        if (isLoadMoreCall) {
-          const combinedActivities = [...prevActivities, ...tranformActivityData];
-          updatedActivities = Array.from(new Set(combinedActivities.map(a => a.id)))
-            .map(id => combinedActivities.find(a => a.id === id))
-            .filter(a => a !== undefined) as ActivityDisplayProps[];
-        } else {
-          updatedActivities = tranformActivityData;
+          if (isLoadMoreCall) {
+            const combinedActivities = [
+              ...prevState.activities,
+              ...tranformActivityData,
+            ];
+            updatedActivities = Array.from(
+              new Map(
+                combinedActivities.map((activity) => [activity.id, activity]),
+              ).values(),
+            ) as ActivityDisplayProps[];
+          } else {
+            updatedActivities = tranformActivityData;
+          }
+
+          updatedActivities.sort((a, b) => {
+            const timeA = a.createdAt
+              ? new Date(a.createdAt).getTime()
+              : Number.MAX_SAFE_INTEGER;
+            const timeB = b.createdAt
+              ? new Date(b.createdAt).getTime()
+              : Number.MAX_SAFE_INTEGER;
+            return timeB - timeA;
+          });
+
+          return {
+            activities: updatedActivities,
+            totalCount: data.totalCount,
+          };
+        });
+
+        if (!isLoadMoreCall && !categoryId) {
+          setCurrentTabActivityCount(data.totalCount);
         }
-      
-        updatedActivities.sort((a, b) => {
-          const timeA = a.createdAt ? new Date(a.createdAt).getTime() : Number.MAX_SAFE_INTEGER;
-          const timeB = b.createdAt ? new Date(b.createdAt).getTime() : Number.MAX_SAFE_INTEGER;
-          return timeB - timeA;
-        });
-
-        setShowLoadMoreButton(updatedActivities.length !== data.totalCount);
-      
-        return updatedActivities;
-      });
-      
-      if (!isLoadMore && !categoryId) {
-        setCurrentTabActivityCount(() => {
-          console.log(data.totalCount)
-          return data.totalCount
-        });
+      } catch (err) {
+        setError(
+          err instanceof Error ? err : new Error("An unknown error occurred"),
+        );
+      } finally {
+        setLoadingState(LoadingState.Idle);
       }
-  
-    } catch (err) {
-      setError(err instanceof Error ? err : new Error('An unknown error occurred'));
-    } finally {
-      setLoading(false);
-      setIsLoadMore(false);
-    }
-  }, [basicCondition, categoryId, offset, limit]);
+    },
+    [basicCondition, categoryId, offset, limit],
+  );
 
   useEffect(() => {
-    if ((loadingState === LoadingState.InitialLoading)|| (loadingState === LoadingState.Idle)) {
-      setLoading(true);
+    if (
+      loadingState === LoadingState.InitialLoading ||
+      loadingState === LoadingState.Idle
+    ) {
       fetchActivities()
-        .then(() => setLoading(false))
-        .catch(error => {
-          setError(error instanceof Error ? error : new Error('An unknown error occurred'));
-          setLoading(false);
-          setIsLoadMore(false);
+        .catch((error) => {
+          setError(
+            error instanceof Error
+              ? error
+              : new Error("An unknown error occurred"),
+          );
+        })
+        .finally(() => {
+          setLoadingState(LoadingState.Idle);
         });
     }
-  }, [basicCondition, categoryId, offset, limit]);
+  }, [basicCondition, categoryId, offset, limit, fetchActivities]);
 
-  const loadMoreActivities = showLoadMoreButton ? () => {
-    return new Promise<void>((resolve, reject) => {
-      const newOffset = offset + limit;
-      setIsLoadMore(true);
-      setLoadingState(LoadingState.LoadingMore);
-      setOffset(newOffset);
-      fetchActivities(true, newOffset) 
-        .then(() => {
-          setIsLoadMore(false);
-          resolve();
-        })
-        .catch(error => {
-          setError(error instanceof Error ? error : new Error('An unknown error occurred'));
-          setIsLoadMore(false);
-          reject(error);
-        });
-    });
-  } : undefined;
+  const loadMoreActivities =
+    activityCollection.activities.length !== activityCollection.totalCount
+      ? () => {
+          return new Promise<void>((resolve, reject) => {
+            const newOffset = offset + limit;
+            setLoadingState(LoadingState.LoadingMore);
+            setOffset(newOffset);
+            fetchActivities(true, newOffset)
+              .then(() => {
+                resolve();
+              })
+              .catch((error) => {
+                setError(
+                  error instanceof Error
+                    ? error
+                    : new Error("An unknown error occurred"),
+                );
+                reject(error);
+              })
+              .finally(() => {
+                setLoadingState(LoadingState.Idle);
+              });
+          });
+        }
+      : undefined;
 
-  return { 
-    loadingActivities: loading, 
-    errorActivities: error, 
-    activities, 
-    currentTabActivityCount, 
-    loadMoreActivities ,
-    showLoadMoreButton
-
+  return {
+    loadingActivities: loadingState === LoadingState.InitialLoading,
+    errorActivities: error,
+    activities: activityCollection.activities,
+    currentTabActivityCount,
+    loadMoreActivities,
   };
 };
 

--- a/src/hooks/activity/useActivityCollection.ts
+++ b/src/hooks/activity/useActivityCollection.ts
@@ -15,20 +15,20 @@ interface ActivityDisplayProps {
   startedAt: Date | null;
   endedAt: Date | null;
   isPrivate: boolean;
+  createdAt: Date | null
 }
 
 type FetchActivityDisplayProps = Pick<ActivityDisplayProps, 'id' | 'title' | 'coverUrl' | 'includeSessionTypes' | 'participantsCount' | 'isPrivate'> & {
   publishedAt: string | null;
   startedAt: string | null;
   endedAt: string | null;
+  createdAt: string | null
 }
 
 type ActivityBasicCondition = {
   organizerId?: string | null;
-  isPrivate?: boolean;
-  publishedAtNotNull?: boolean;
-  activityEndedAfterNow?: boolean;
   appId: string;
+  scenario: 'holding' | 'finished' | 'draft' | 'privateHolding';
 };
 
 interface FetchActivitiesResponse {
@@ -42,13 +42,16 @@ const fetchActivitiesApi = (
   limit: number, 
   offset: number
 ) => {
-  return axios.post<FetchActivitiesResponse>('https://175d-143-244-40-17.ngrok-free.app/activity_collection', {
-    basicCondition,
-    categoryId,
-    limit,
-    offset,
+  return axios.get<FetchActivitiesResponse>(`${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/activity/activity_collection`, {
+    params: {
+      basicCondition,
+      categoryId,
+      limit,
+      offset,
+    }
   }).then(response => {
     response.data.activities = response.data.activities || [];
+    console.log('response.data', response.data)
     return response.data;
   });
 };
@@ -59,6 +62,7 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
   const [error, setError] = useState<Error | null>(null);
   const [currentTabActivityCount, setCurrentTabActivityCount] = useState<number>(0);
   const [offset, setOffset] = useState<number>(0);
+  const [isLoadMore, setIsLoadMore] = useState<boolean>(false);
 
   const limit = 20;
 
@@ -69,8 +73,13 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
       ...activity,
       publishedAt: transformDate(activity.publishedAt),
       startedAt: transformDate(activity.startedAt),
-      endedAt: transformDate(activity.endedAt)
+      endedAt: transformDate(activity.endedAt),
+      createdAt: transformDate(activity.createdAt),
   })
+
+  useEffect(() => {
+    setOffset(0);
+  }, [basicCondition, categoryId]);
 
 
   const fetchActivities = useCallback(async () => {
@@ -78,23 +87,43 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
     try {
       const data = await fetchActivitiesApi(basicCondition, categoryId, limit, offset);
 
+      console.log('tranformActivityData', data )
+
       const tranformActivityData = data.activities.map(transformActivity)
+    
 
       setActivities(prevActivities => {
-
-        const combinedActivities = [...prevActivities, ...tranformActivityData];
-
-        const uniqueActivities = Array.from(new Set(combinedActivities.map(a => a.id)))
-        .map(id => combinedActivities.find(a => a.id === id))
-        .filter(a => a !== undefined) as ActivityDisplayProps[];
+        let updatedActivities;
       
-        return uniqueActivities;
+        if (isLoadMore) {
+          const combinedActivities = [...prevActivities, ...tranformActivityData];
+          updatedActivities = Array.from(new Set(combinedActivities.map(a => a.id)))
+            .map(id => combinedActivities.find(a => a.id === id))
+            .filter(a => a !== undefined) as ActivityDisplayProps[];
+        } else {
+          updatedActivities = tranformActivityData;
+        }
+      
+        updatedActivities.sort((a, b) => {
+          const timeA = a.createdAt ? new Date(a.createdAt).getTime() : Number.MAX_SAFE_INTEGER;
+          const timeB = b.createdAt ? new Date(b.createdAt).getTime() : Number.MAX_SAFE_INTEGER;
+          return timeB - timeA;
+        });
+
+        console.log('updatedActivities',updatedActivities)
+      
+        return updatedActivities;
       });
-      setCurrentTabActivityCount(data.totalCount);
+      
+      setCurrentTabActivityCount(() => {
+        console.log(data.totalCount)
+        return data.totalCount
+      });
     } catch (err) {
       setError(err instanceof Error ? err : new Error('An unknown error occurred'));
     } finally {
       setLoading(false);
+      setIsLoadMore(false);
     }
   }, [basicCondition, categoryId, offset, limit]);
 
@@ -103,10 +132,20 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
   }, [fetchActivities]);
 
   const loadMoreActivities = useCallback(() => {
-    setOffset(prevOffset => prevOffset + limit);
+    setIsLoadMore(true);
+    
+    setOffset((prevOffset) => {
+      return prevOffset + limit
+    });
   }, [limit]);
 
-  return { loadingActivities: loading, errorActivities: error, activities, currentTabActivityCount, loadMoreActivities };
+  return { 
+    loadingActivities: loading, 
+    errorActivities: error, 
+    activities, 
+    currentTabActivityCount, 
+    loadMoreActivities 
+  };
 };
 
 export default useActivityCollection;

--- a/src/hooks/activity/useActivityCollection.ts
+++ b/src/hooks/activity/useActivityCollection.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 import { useState, useEffect, useCallback } from 'react';
-import { ActivityAdminProps } from '../../types/activity';
+
 
 interface ActivityDisplayProps {
   id: string;
@@ -51,7 +51,6 @@ const fetchActivitiesApi = (
     }
   }).then(response => {
     response.data.activities = response.data.activities || [];
-    console.log('response.data', response.data)
     return response.data;
   });
 };
@@ -63,6 +62,7 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
   const [currentTabActivityCount, setCurrentTabActivityCount] = useState<number>(0);
   const [offset, setOffset] = useState<number>(0);
   const [isLoadMore, setIsLoadMore] = useState<boolean>(false);
+  const [showLoadMoreButton , setShowLoadMoreButton] = useState<boolean>(false)
 
   const limit = 20;
 
@@ -110,15 +110,18 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
           return timeB - timeA;
         });
 
-        console.log('updatedActivities',updatedActivities)
+        setShowLoadMoreButton(updatedActivities.length !== data.totalCount);
       
         return updatedActivities;
       });
       
-      setCurrentTabActivityCount(() => {
-        console.log(data.totalCount)
-        return data.totalCount
-      });
+      if (!isLoadMore && !categoryId) {
+        setCurrentTabActivityCount(() => {
+          console.log(data.totalCount)
+          return data.totalCount
+        });
+      }
+  
     } catch (err) {
       setError(err instanceof Error ? err : new Error('An unknown error occurred'));
     } finally {
@@ -144,7 +147,9 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
     errorActivities: error, 
     activities, 
     currentTabActivityCount, 
-    loadMoreActivities 
+    loadMoreActivities ,
+    showLoadMoreButton
+
   };
 };
 

--- a/src/hooks/activity/useActivityCollection.ts
+++ b/src/hooks/activity/useActivityCollection.ts
@@ -1,7 +1,11 @@
 import axios from 'axios';
 import { useState, useEffect, useCallback } from 'react';
-
-
+enum LoadingState {
+  Idle,
+  InitialLoading,
+  LoadingMore,
+  None
+}
 interface ActivityDisplayProps {
   id: string;
   coverUrl: string | null;
@@ -64,6 +68,7 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
   const [isLoadMore, setIsLoadMore] = useState<boolean>(false);
   const [showLoadMoreButton , setShowLoadMoreButton] = useState<boolean>(false)
   const [isInitialLoad, setIsInitialLoad] = useState<boolean>(true); // 新添加的状态变量
+  const [loadingState, setLoadingState] = useState<LoadingState>(LoadingState.Idle);
 
   const limit = 20;
 
@@ -80,7 +85,7 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
 
   useEffect(() => {
     setOffset(0);
-    setIsInitialLoad(true); 
+    setLoadingState(LoadingState.InitialLoading);
   }, [basicCondition, categoryId]);
 
 
@@ -134,7 +139,7 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
   }, [basicCondition, categoryId, offset, limit]);
 
   useEffect(() => {
-    if (isInitialLoad) {
+    if ((loadingState === LoadingState.InitialLoading)|| (loadingState === LoadingState.Idle)) {
       setLoading(true);
       fetchActivities()
         .then(() => setLoading(false))
@@ -144,14 +149,13 @@ const useActivityCollection = (basicCondition: ActivityBasicCondition, categoryI
           setIsLoadMore(false);
         });
     }
-    setIsInitialLoad(true);
   }, [basicCondition, categoryId, offset, limit]);
 
   const loadMoreActivities = showLoadMoreButton ? () => {
     return new Promise<void>((resolve, reject) => {
       const newOffset = offset + limit;
       setIsLoadMore(true);
-      setIsInitialLoad(false);
+      setLoadingState(LoadingState.LoadingMore);
       setOffset(newOffset);
       fetchActivities(true, newOffset) 
         .then(() => {

--- a/src/hooks/activity/useActivityCollection.ts
+++ b/src/hooks/activity/useActivityCollection.ts
@@ -28,6 +28,7 @@ type ActivityBasicCondition = {
   isPrivate?: boolean;
   publishedAtNotNull?: boolean;
   activityEndedAfterNow?: boolean;
+  appId: string;
 };
 
 interface FetchActivitiesResponse {

--- a/src/hooks/activity/useActivityCollection.ts
+++ b/src/hooks/activity/useActivityCollection.ts
@@ -7,6 +7,7 @@ import {
   ActivityBasicCondition,
   FetchActivitiesResponse,
 } from "./activitiyCollectionType";
+import { useAuth } from "lodestar-app-element/src/contexts/AuthContext";
 
 enum LoadingState {
   Idle,
@@ -16,6 +17,7 @@ enum LoadingState {
 }
 
 const fetchActivitiesApi = (
+  authToken: string | null,
   basicCondition: ActivityBasicCondition,
   categoryId: string | null,
   limit: number,
@@ -25,6 +27,9 @@ const fetchActivitiesApi = (
     .get<FetchActivitiesResponse>(
       `${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/activity/activity_collection`,
       {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
         params: {
           basicCondition,
           categoryId,
@@ -43,6 +48,7 @@ const useActivityCollection = (
   basicCondition: ActivityBasicCondition,
   categoryId: string | null,
 ) => {
+  const { authToken } = useAuth(); 
   const [activityCollection, setActivityCollection] =
     useState<ActivityCollectionState>({
       activities: [],
@@ -84,6 +90,7 @@ const useActivityCollection = (
 
       try {
         const data = await fetchActivitiesApi(
+          authToken,
           basicCondition,
           categoryId,
           limit,


### PR DESCRIPTION
[trello](https://trello.com/c/I9DHC4rr)

## 描述
需要將 GET_ACTIVITY_COLLECTION_ADMIN query 移至 lodestar-server

## 更改的地方
### `src/components/activity/ActivityCollectionTabs.tsx` 
- 新增與後端api溝通的參數 adminCondition
- 使用新的hook `useActivityCollection`
- 不動既定的UI
### `src/hooks/activity/activitiyCollectionType.ts`
- 為 `useActivityCollection` 專用的type
### `src/hooks/activity/useActivityCollection.ts`
- 後端API執行方法：`fetchActivitiesApi`
- `useActivityCollection` hook
  -  `fetchActivities`為最主要呼叫執行api `fetchActivitiesApi` 的地方
  -  有三個情境: 初次載入(頁面載入或basicCondition條件改變) / category篩選 / 顯示更多
  -  useEffect 負責處理 初次載入 / category篩選 , 當 basicCondition, categoryId 改變時去呼叫`fetchActivities`
  - loadMoreActivities 負責處理顯示更多，執行時會去呼叫`fetchActivities` , 並且帶入 isLoadMoreCall = true -> 因為這是為了判斷api帶回來應該要怎麼處理數據-> 如過是loadMoreActivities 的話就要將新帶回來的數據與原有數據合併

## 操作影片

https://github.com/urfit-tech/lodestar-app-admin/assets/107536598/25ad94e9-3796-4a26-8713-30103f887a2a

