### PR TITLE
feat: add sales module permission group judgement to menu

### DIFF
--- a/src/components/admin/AdminMenu.tsx
+++ b/src/components/admin/AdminMenu.tsx
@@ -53,6 +53,13 @@ const AdminMenu: React.FC<MenuProps & { opened?: boolean }> = ({ opened, childre
   const [openKeys, setOpenKeys] = useState<React.Key[]>([])
   const payload = authToken ? parsePayload(authToken) : null
   const isBusiness = payload && payload.isBusiness
+  const hasSaleGroupPermission = [
+    permissions.GROSS_SALES_ADMIN,
+    permissions.GROSS_SALES_NORMAL,
+    permissions.SALES_RECORDS_ADMIN,
+    permissions.SALES_RECORDS_DETAILS,
+    permissions.SALES_RECORDS_NORMAL,
+  ].some(permission => permission)
   const defaultMenuItems: {
     permissionIsAllowed: boolean
     icon: React.FunctionComponent<React.SVGProps<SVGSVGElement>>
@@ -65,7 +72,7 @@ const AdminMenu: React.FC<MenuProps & { opened?: boolean }> = ({ opened, childre
     }[]
   }[] = [
     {
-      permissionIsAllowed: !!enabledModules.sale_manager,
+      permissionIsAllowed: !!enabledModules.sale_manager && hasSaleGroupPermission,
       icon: () => <MoneyCircleIcon />,
       key: 'sales',
       name: formatMessage(adminMessages.AdminMenu.salesAdmin),


### PR DESCRIPTION
## 描述
由於現在menu的銷售管理模組並沒有新增判斷權限，導致就算只有進入後台的一般權限也能進入頁面查看

## 作法
新增權限判斷

## 檢查
若沒有銷售權限組，預設會跳個人設定頁面
<img width="542" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107536598/f65cceb1-0036-41ca-9ae9-ab5980245a50">


## 備註
查看所有銷售總額 GROSS_SALES_ADMIN
查看個人銷售總額 GROSS_SALES_NORMAL
查看所有銷售紀錄 SALES_RECORDS_ADMIN
查看消費者細項 SALES_RECORDS_DETAILS
查看個人銷售紀錄 SALES_RECORDS_NORMAL