### PR TITLE
feat: add timestamp for manager assignment

### DIFF
--- a/src/pages/SalesLeadDeliveryPage/SalesLeadDeliveryPage.tsx
+++ b/src/pages/SalesLeadDeliveryPage/SalesLeadDeliveryPage.tsx
@@ -591,7 +591,10 @@ const ResultSection: React.FC<{ result: AssignResult; onBack?: () => void }> = (
 
 const UPDATE_LEAD_MANAGER = gql`
   mutation UPDATE_LEAD_MANAGER($memberIds: [String!], $managerId: String) {
-    update_member(where: { id: { _in: $memberIds } }, _set: { manager_id: $managerId }) {
+    update_member(
+      where: { id: { _in: $memberIds } }
+      _set: { manager_id: $managerId, last_manager_assigned_at: "now()" }
+    ) {
       affected_rows
     }
   }


### PR DESCRIPTION
Introduced tracking of the last time a manager was assigned to a member in the database schema and GraphQL mutation. The
`last_manager_assigned_at` field is now automatically set to the current timestamp when updating the lead manager, allowing for better tracking of manager assignment history and enhanced reporting capabilities.