### PR TITLE
fix: useAppointmentEnrollmentCollection finished condition ended_at

### DIFF
--- a/src/hooks/appointment.ts
+++ b/src/hooks/appointment.ts
@@ -1,5 +1,6 @@
 import { useMutation, useQuery } from '@apollo/client'
 import { gql } from '@apollo/client'
+import dayjs from 'dayjs'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import moment from 'moment'
 import { useMemo } from 'react'
@@ -206,7 +207,7 @@ export const useAppointmentEnrollmentCollection = (
           started_at: { _gte: startedAt },
           canceled_at: { _is_null: true },
           ended_at: {
-            _lte: endedAt || moment().startOf('minute').toDate(),
+            _lte: dayjs().isBefore(dayjs(endedAt)) ? moment().startOf('minute').toDate() : endedAt,
           },
         }
       : {}


### PR DESCRIPTION
Why
---
- Selecting the Ended tab shows an unfinished meeting.

What
---
- Fixed the issue where unfinished meetings will not appear when selecting the Ended tab.

Before
---
<img width="1161" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107075349/9f874952-4801-4458-b803-dd476adf978b">
<img width="1139" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107075349/566b18bd-74dc-41f9-a232-26f94601fd05">


After
---
<img width="1151" alt="截圖 2024-04-15 上午11 20 46" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107075349/21f87226-dbd2-4508-b903-77c012f19244">
<img width="1126" alt="截圖 2024-04-15 上午11 21 07" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107075349/1145f9cb-dc77-48a8-83d8-cf06476154ef">