### PR TITLE
fix: SalesLeadDeliveryPage currentMembers default empty array

### DIFF
--- a/src/pages/SalesLeadDeliveryPage/SalesLeadDeliveryPage.tsx
+++ b/src/pages/SalesLeadDeliveryPage/SalesLeadDeliveryPage.tsx
@@ -780,7 +780,7 @@ const ConfirmSection: React.FC<{
           <MemberCollectionTableBlock
             visibleColumnIds={visibleColumnIds}
             loadingMembers={loadingLeadCandidates || !members}
-            currentMembers={members}
+            currentMembers={members || []}
             limit={limit}
             properties={properties}
             visibleShowMoreButton={false}


### PR DESCRIPTION
Why
---
- When SalesLeadDeliveryPage uses MemberCollectionBlock, the currentMembers brought in is undefined, thus an error occurs.

What
---
- Defaults the currentMembers props brought into MemberCollectionBlock to an empty array
