### PR TITLE
fix: MemberCollectionTableBlock currentMembers default empty array

### DIFF
--- a/src/pages/MemberCollectionAdminPage/MemberCollectionAdminPage.tsx
+++ b/src/pages/MemberCollectionAdminPage/MemberCollectionAdminPage.tsx
@@ -435,7 +435,7 @@ export const MemberCollectionTableBlock: React.VFC<{
 }> = ({
   visibleColumnIds,
   loadingMembers,
-  currentMembers,
+  currentMembers = [],
   limit,
   nextToken,
   fieldFilter = {},


### PR DESCRIPTION
Why
---
- When SalesLeadDeliveryPage uses MemberCollectionBlock, the currentMembers brought in is undefined, thus an error occurs.

What
---
- Defaults the currentMembers props brought into MemberCollectionBlock to an empty array
