### PR TITLE
Refactor Program Layout Template 

### DIFF
--- a/src/components/common/ProductCreationModal.tsx
+++ b/src/components/common/ProductCreationModal.tsx
@@ -10,7 +10,6 @@ import { handleError } from '../../helpers'
 import { commonMessages, errorMessages, merchandiseMessages } from '../../helpers/translation'
 import { useGetProgramLayoutTemplates } from '../../hooks/data'
 import { ClassType } from '../../types/general'
-import { ProgramLayoutTemplate } from '../../types/program'
 import AdminModal, { AdminModalProps } from '../admin/AdminModal'
 import CategorySelector from '../form/CategorySelector'
 import ContentCreatorSelector from '../form/ContentCreatorSelector'
@@ -54,7 +53,7 @@ const ProductCreationModal: React.FC<
       isSubscription?: boolean
       isPhysical?: boolean
       isCustomized?: boolean
-      programLayoutTemplateData?: ProgramLayoutTemplate
+      programLayoutTemplateId?: string | null
     }) => Promise<any>
     allowedPermissions?: string[]
     creatorAppellation?: string
@@ -80,7 +79,7 @@ const ProductCreationModal: React.FC<
   const { currentMemberId } = useAuth()
   const { enabledModules } = useApp()
   const [loading, setLoading] = useState(false)
-  const { programLayoutTemplates, defaultFixedTemplate } = useGetProgramLayoutTemplates()
+  const { programLayoutTemplates } = useGetProgramLayoutTemplates()
 
   const handleSubmit = () => {
     form
@@ -98,9 +97,7 @@ const ProductCreationModal: React.FC<
           isSubscription: withProgramType ? values.isSubscription : undefined,
           isPhysical: withMerchandiseType ? values.merchandiseType.includes('physical') : undefined,
           isCustomized: withMerchandiseType ? values.merchandiseType.includes('customized') : undefined,
-          programLayoutTemplateData: values.programLayoutTemplateId
-            ? programLayoutTemplates.filter(template => template.id === values.programLayoutTemplateId)[0]
-            : defaultFixedTemplate,
+          programLayoutTemplateId: values.programLayoutTemplateId ?? null,
         }).finally(() => setLoading(false))
       })
       .catch(handleError)
@@ -203,10 +200,7 @@ const ProductCreationModal: React.FC<
         )}
         {withProgramLayoutTemplateType && (
           <Form.Item label={formatMessage(commonMessages.label.selectTemplate)} name="programLayoutTemplateId">
-            <ProgramLayoutTemplateSelect
-              programLayoutTemplates={programLayoutTemplates}
-              defaultTemplate={defaultFixedTemplate}
-            />
+            <ProgramLayoutTemplateSelect programLayoutTemplates={programLayoutTemplates} />
           </Form.Item>
         )}
       </Form>

--- a/src/components/form/ProgramLayoutTemplateSelector.tsx
+++ b/src/components/form/ProgramLayoutTemplateSelector.tsx
@@ -1,11 +1,15 @@
 import { Select } from 'antd'
 import React from 'react'
-import { ProgramLayoutTemplate } from '../../types/program'
+
+type ProgramLayoutTemplate = {
+  id: string
+  name: string
+}
 
 export const ProgramLayoutTemplateSelect: React.FC<{
   value?: string
   programLayoutTemplates: ProgramLayoutTemplate[]
-  defaultTemplate?: ProgramLayoutTemplate
+  defaultTemplate?: ProgramLayoutTemplate | null
   onChange?: (value: string) => void
 }> = ({ value, programLayoutTemplates, defaultTemplate, onChange }) => {
   return (

--- a/src/components/form/ProgramLayoutTemplateSelector.tsx
+++ b/src/components/form/ProgramLayoutTemplateSelector.tsx
@@ -12,7 +12,6 @@ export const ProgramLayoutTemplateSelect: React.FC<{
   programLayoutTemplates: ProgramLayoutTemplate[]
   onChange?: (value: string) => void
 }> = ({ value, programLayoutTemplates, onChange }) => {
-  console.log('ProgramLayoutTemplateSelect', value)
   const defaultTemplate = {
     id: DEFAULT_TEMPLATE,
     name: '標準版型-sys',

--- a/src/components/form/ProgramLayoutTemplateSelector.tsx
+++ b/src/components/form/ProgramLayoutTemplateSelector.tsx
@@ -1,5 +1,6 @@
 import { Select } from 'antd'
 import React from 'react'
+import { DEFAULT_TEMPLATE } from '../../pages/ProgramAdminPage/ProgramBasicForm'
 
 type ProgramLayoutTemplate = {
   id: string
@@ -9,12 +10,20 @@ type ProgramLayoutTemplate = {
 export const ProgramLayoutTemplateSelect: React.FC<{
   value?: string
   programLayoutTemplates: ProgramLayoutTemplate[]
-  defaultTemplate?: ProgramLayoutTemplate | null
   onChange?: (value: string) => void
-}> = ({ value, programLayoutTemplates, defaultTemplate, onChange }) => {
+}> = ({ value, programLayoutTemplates, onChange }) => {
+  console.log('ProgramLayoutTemplateSelect', value)
+  const defaultTemplate = {
+    id: DEFAULT_TEMPLATE,
+    name: '標準版型-sys',
+  }
+  if (!value) {
+    value = DEFAULT_TEMPLATE
+  }
+  const templates = [...programLayoutTemplates, defaultTemplate]
   return (
     <Select value={value} onChange={onChange} defaultValue={defaultTemplate?.id}>
-      {programLayoutTemplates.map(programLayoutTemplate => (
+      {templates.map(programLayoutTemplate => (
         <Select.Option key={programLayoutTemplate.id} value={programLayoutTemplate.id}>
           {programLayoutTemplate.name}
         </Select.Option>

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -13,10 +13,6 @@ import hasura from '../hasura'
 import { Attachment, Category, ClassType, ProductInventoryLogProps } from '../types/general'
 import { InvoiceProps, ShippingProps } from '../types/merchandise'
 import {
-  LayoutTemplateModuleType,
-  ModuleDataProps,
-  ModuleNameProps,
-  ProgramLayoutTemplate,
   ProgramPlanPeriodType,
 } from '../types/program'
 import { MetaProductType } from 'lodestar-app-element/src/types/metaProduct'
@@ -1374,46 +1370,12 @@ export const useGetProgramLayoutTemplates = () => {
     `,
   )
 
-  const constructModuleData = (moduleName: ModuleNameProps | undefined): ModuleDataProps | undefined => {
-    if (!moduleName) return
-    const moduleData: ModuleDataProps = {}
-
-    Object.entries(moduleName).forEach(([_, value]) => {
-      let { name, ...rest } = value
-      let defaultValue = null
-
-      switch (value.type) {
-        case LayoutTemplateModuleType.DATE:
-          defaultValue = null
-          break
-        case LayoutTemplateModuleType.NUMBER:
-          defaultValue = null
-          break
-        default:
-          break
-      }
-
-      Object.defineProperty(moduleData, name, {
-        value: {
-          value: defaultValue,
-          ...rest,
-        },
-        writable: true,
-        enumerable: true,
-        configurable: true,
-      })
-    })
-
-    return moduleData
-  }
-
   const layoutTemplates =
     loading || error || !data
       ? []
       : data.program_layout_template.map(layoutTemplate => ({
           id: layoutTemplate.id,
           name: layoutTemplate.name || '',
-          moduleData: constructModuleData(layoutTemplate?.module_name),
         }))
 
   return {

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -1407,16 +1407,6 @@ export const useGetProgramLayoutTemplates = () => {
     return moduleData
   }
 
-  const isModuleDataAvailable = (moduleData: ModuleDataProps | undefined | null) => {
-    if (!moduleData) return false
-    return Boolean(moduleData) && !isEmpty(moduleData)
-  }
-
-  const getDefaultProgramLayoutTemplate = (layoutTemplates: ProgramLayoutTemplate[]) => {
-    if (!layoutTemplates.length) return
-    return layoutTemplates.filter(template => !isModuleDataAvailable(template.moduleData))[0]
-  }
-
   const layoutTemplates =
     loading || error || !data
       ? []
@@ -1429,7 +1419,6 @@ export const useGetProgramLayoutTemplates = () => {
   return {
     loading,
     programLayoutTemplates: layoutTemplates,
-    defaultFixedTemplate: getDefaultProgramLayoutTemplate(layoutTemplates),
     refetch,
   }
 }

--- a/src/hooks/program.ts
+++ b/src/hooks/program.ts
@@ -297,7 +297,14 @@ export const useProgram = (programId: string) => {
           programLayoutTemplateId: config.program_layout_template_id,
           moduleData: config.module_data,
           isActive: config.is_active,
-          ProgramLayoutTemplate: config.program_layout_template,
+          ProgramLayoutTemplate: {
+            id: config.program_layout_template.id,
+            customAttribute: config.program_layout_template.module_name?.map((value: {id: string , name: string, type: string}) => ({
+              id: value?.id,
+              name: value?.name,
+              type: value?.type
+            }))
+          },
         }))[0] || [],
     }
   }, [data, error, loading])

--- a/src/hooks/program.ts
+++ b/src/hooks/program.ts
@@ -152,7 +152,7 @@ export const useProgram = (programId: string) => {
             description
             feedback
           }
-          program_layout_template_configs(where: { program_id: { _eq: $programId }, is_active: { _eq: true } }) {
+          program_layout_template_config{
             id
             program_id
             program_layout_template_id
@@ -167,7 +167,7 @@ export const useProgram = (programId: string) => {
         }
       }
     `,
-    { variables: { programId }, fetchPolicy: 'no-cache' },
+    { variables: { programId }, fetchPolicy: 'network-only' },
   )
 
   const program: ProgramAdminProps | null = useMemo(() => {
@@ -290,22 +290,20 @@ export const useProgram = (programId: string) => {
         description: programApproval.description || '',
         feedback: programApproval.feedback || '',
       })),
-      programLayoutTemplateConfig:
-        data?.program_by_pk.program_layout_template_configs.map(config => ({
-          id: config.id,
-          programId: config.program_id,
-          programLayoutTemplateId: config.program_layout_template_id,
-          moduleData: config.module_data,
-          isActive: config.is_active,
-          ProgramLayoutTemplate: {
-            id: config.program_layout_template.id,
-            customAttribute: config.program_layout_template.module_name?.map((value: {id: string , name: string, type: string}) => ({
-              id: value?.id,
-              name: value?.name,
-              type: value?.type
-            }))
-          },
-        }))[0] || [],
+      programLayoutTemplateConfig: data?.program_by_pk?.program_layout_template_config?.id ? {
+        id: data?.program_by_pk?.program_layout_template_config?.id,
+        programId: data?.program_by_pk?.program_layout_template_config?.program_id,
+        programLayoutTemplateId: data?.program_by_pk?.program_layout_template_config?.program_layout_template_id,
+        moduleData: data?.program_by_pk?.program_layout_template_config?.module_data,
+        ProgramLayoutTemplate: {
+          id: data?.program_by_pk?.program_layout_template_config?.program_layout_template?.id,
+          customAttribute: data?.program_by_pk?.program_layout_template_config?.program_layout_template?.module_name.map((value: {id:string, name: string, type: string}) => ({
+            id: value?.id,
+            name: value?.name,
+            type: value?.type
+          }))
+        }
+      } : null
     }
   }, [data, error, loading])
   return {

--- a/src/hooks/program.ts
+++ b/src/hooks/program.ts
@@ -297,7 +297,7 @@ export const useProgram = (programId: string) => {
         moduleData: data?.program_by_pk?.program_layout_template_config?.module_data,
         ProgramLayoutTemplate: {
           id: data?.program_by_pk?.program_layout_template_config?.program_layout_template?.id,
-          customAttribute: data?.program_by_pk?.program_layout_template_config?.program_layout_template?.module_name.map((value: {id:string, name: string, type: string}) => ({
+          customAttributes: data?.program_by_pk?.program_layout_template_config?.program_layout_template?.module_name.map((value: {id:string, name: string, type: string}) => ({
             id: value?.id,
             name: value?.name,
             type: value?.type

--- a/src/hooks/programLayoutTemplate.ts
+++ b/src/hooks/programLayoutTemplate.ts
@@ -1,4 +1,4 @@
-import { gql, useMutation } from '@apollo/client';
+import { gql, useApolloClient, useMutation  } from '@apollo/client';
 
 const UpdateTemplateCustomAttributeFormValue = gql`
   mutation UpdateTemplateCustomAttributeFormValue(
@@ -18,6 +18,36 @@ const UpdateTemplateCustomAttributeFormValue = gql`
     }
   }
 `
+
+
+const UpdateTemplateForProgram = gql`
+  mutation updateTemplateForProgram($programId: uuid, $program_layout_template_config_id: uuid) {
+    update_program(
+      where: { id: { _eq: $programId } }
+      _set: { program_layout_template_config_id: $program_layout_template_config_id }
+    ) {
+      affected_rows
+    }
+  }
+`
+
+const GetProgramLayoutConfigId =gql`
+  query GetProgramLayoutConfigId($programId: uuid, $programLayoutTemplateId: uuid) {
+  program_layout_template_config(where: { program_id: { _eq: $programId }, program_layout_template_id: { _eq: $programLayoutTemplateId } }) {
+    id
+  }
+}
+`
+const InsertProgramLayoutTemplateConfig = gql`
+  mutation InsertProgramLayoutTemplateConfig($program_id: uuid!, $program_layout_template_id: uuid!) {
+    insert_program_layout_template_config(objects: {program_id: $program_id, program_layout_template_id: $program_layout_template_id}) {
+      affected_rows
+      returning {
+        id
+      }
+    }
+  }
+`;
 
 export const useUpdateCustomAttributeFormValue = (programId: string, programLayoutTemplateConfigId: string) => {
   const [updateCustomAttributesValueGql, { loading, error, data }] = useMutation(
@@ -43,3 +73,68 @@ export const useUpdateCustomAttributeFormValue = (programId: string, programLayo
   return { updateCustomAttributesValue, loading, error, data };
 };
 
+
+export const useActivatedTemplateForProgram = () => {
+  const [updateTemplateForProgram] = useMutation(UpdateTemplateForProgram);
+  const [insertProgramLayoutTemplateConfig] = useMutation(InsertProgramLayoutTemplateConfig)
+  const queryClient = useApolloClient()
+
+  const activatedTemplateForProgram = async (
+    programId: string,
+    programLayoutTemplateId: string | null
+  ): Promise<{ success: boolean; configId: string | null }> => {
+    if (!programLayoutTemplateId) {
+      await updateTemplateForProgram({
+        variables: {
+          programId,
+          program_layout_template_config_id: null,
+        },
+      });
+      return { success: true, configId: null };
+    }
+  
+    try {
+      const { data } = await queryClient.query({
+        query: GetProgramLayoutConfigId,
+        variables: {
+          programId,
+          programLayoutTemplateId,
+        },
+      });
+  
+      const existConfigId = data?.program_layout_template_config?.[0]?.id;
+      let configId = existConfigId;
+  
+      if (!existConfigId) {
+        const activateResult = await insertProgramLayoutTemplateConfig({
+          variables: {
+            program_id: programId,
+            program_layout_template_id: programLayoutTemplateId,
+          },
+        });
+  
+        const returningArray = activateResult?.data?.insert_program_layout_template_config?.returning;
+  
+        const insertConfigId = returningArray?.[0]?.id;
+        configId = insertConfigId ?? null;
+      }
+  
+      await updateTemplateForProgram({
+        variables: {
+          programId,
+          program_layout_template_config_id: configId,
+        },
+      });
+  
+      return { success: true, configId };
+    } catch (error) {
+      console.error('Error during activation and update:', error);
+      throw error;
+    }
+  };
+  
+  
+  return {
+    activatedTemplateForProgram,
+  };
+};

--- a/src/hooks/programLayoutTemplate.ts
+++ b/src/hooks/programLayoutTemplate.ts
@@ -21,10 +21,10 @@ const UpdateTemplateCustomAttributeFormValue = gql`
 
 
 const UpdateTemplateForProgram = gql`
-  mutation updateTemplateForProgram($programId: uuid, $program_layout_template_config_id: uuid) {
+  mutation updateTemplateForProgram($programId: uuid, $activated_layout_template_config_id: uuid) {
     update_program(
       where: { id: { _eq: $programId } }
-      _set: { program_layout_template_config_id: $program_layout_template_config_id }
+      _set: { activated_layout_template_config_id: $activated_layout_template_config_id }
     ) {
       affected_rows
     }
@@ -87,7 +87,7 @@ export const useActivatedTemplateForProgram = () => {
       await updateTemplateForProgram({
         variables: {
           programId,
-          program_layout_template_config_id: null,
+          activated_layout_template_config_id: null,
         },
       });
       return { success: true, configId: null };
@@ -123,7 +123,7 @@ export const useActivatedTemplateForProgram = () => {
       await updateTemplateForProgram({
         variables: {
           programId,
-          program_layout_template_config_id: configId,
+          activated_layout_template_config_id: configId,
         },
       });
   

--- a/src/hooks/programLayoutTemplate.ts
+++ b/src/hooks/programLayoutTemplate.ts
@@ -1,19 +1,4 @@
-import { useQuery, gql, useMutation } from '@apollo/client';
-import { first } from 'lodash';
-import moment, { MomentInput } from 'moment';
-
-const GetProgramTemplateLayoutFormAndValue = gql`
-  query GetProgramTemplateLayoutFormAndValue($id: uuid!) {
-    program_layout_template_config(where: { id: { _eq: $id } }) {
-      module_data
-      id
-      program_layout_template {
-        id
-        module_name
-      }
-    }
-  }
-`;
+import { gql, useMutation } from '@apollo/client';
 
 const UpdateTemplateCustomAttributeFormValue = gql`
   mutation UpdateTemplateCustomAttributeFormValue(
@@ -33,75 +18,6 @@ const UpdateTemplateCustomAttributeFormValue = gql`
     }
   }
 `
-
-type CustomAttribute = {
-  id: string;
-  name: string;
-  type: "Number" | "Date" | "Text";
-};
-
-type LayoutTemplateCustomAttribute = {
-  id: string;
-  customAttributes: CustomAttribute[];
-};
-
-type ProgramLayoutTemplateConfig = {
-  id: string;
-  customAttributeValue: Record<string, any>;
-};
-
-export const useProgramLayoutTemplate = (id: string) => {
-  const {
-    loading: layoutTemplateLoading,
-    error,
-    data,
-    refetch
-  } = useQuery(GetProgramTemplateLayoutFormAndValue, {
-    variables: { id },
-  });
-
-  const rawLayoutTemplateDefinition = data?.program_layout_template_config?.length
-    ? (first(data.program_layout_template_config) as any).program_layout_template
-    : null;
-  const rawLayoutTemplateFormValue = data?.program_layout_template_config?.length
-    ? first(data.program_layout_template_config) as any
-    : null;
-
-    const customAttributesDefinitions: LayoutTemplateCustomAttribute | null = rawLayoutTemplateDefinition
-    ? {
-        id: rawLayoutTemplateDefinition.id,
-        customAttributes: rawLayoutTemplateDefinition.module_name.map((v: { id: string; name: string; type: string }) => ({
-          id: v.id,
-          name: v.name,
-          type: v.type === 'Number' || v.type === 'Date' || v.type === 'Text' ? v.type : 'Text',
-        })),
-      }
-    : null;
-    
-    const isMomentInput = (value: any): value is MomentInput => {
-      return moment(value).isValid();
-    };
-    
-    const customAttributesFormValue: ProgramLayoutTemplateConfig | null = rawLayoutTemplateFormValue
-      ? {
-          id: rawLayoutTemplateFormValue.id,
-          customAttributeValue: Object.fromEntries(
-            Object.entries(rawLayoutTemplateFormValue.module_data).map(([key, value]) => {
-              const attributeDefinition = customAttributesDefinitions?.customAttributes.find(attr => attr.id === key);
-              if (attributeDefinition && attributeDefinition.type === 'Date' && isMomentInput(value)) {
-                return [key, moment(value)];
-              }
-              return [key, value];
-            })
-          ),
-        }
-      : null;
-    
-  
-
-  return { layoutTemplateLoading, error, customAttributesDefinitions, customAttributesFormValue, refetchLayoutTemplate: refetch };
-};
-
 
 export const useUpdateCustomAttributeFormValue = (programId: string, programLayoutTemplateConfigId: string) => {
   const [updateCustomAttributesValueGql, { loading, error, data }] = useMutation(

--- a/src/hooks/programLayoutTemplate.ts
+++ b/src/hooks/programLayoutTemplate.ts
@@ -1,0 +1,73 @@
+import { useQuery, gql } from '@apollo/client';
+import { first } from 'lodash';
+
+const GetProgramTemplateLayoutFormAndValue = gql`
+  query GetProgramTemplateLayoutFormAndValue($id: uuid!) {
+    program_layout_template_config(where: { id: { _eq: $id } }) {
+      module_data
+      id
+      program_layout_template {
+        id
+        module_name
+      }
+    }
+  }
+`;
+
+type CustomAttribute = {
+  id: string;
+  name: string;
+  type: string;
+};
+
+type LayoutTemplateCustomAttribute = {
+  id: string;
+  customAttributes: CustomAttribute[];
+};
+
+type ProgramLayoutTemplateConfig = {
+  id: string;
+  customAttributeValue: Record<string, any>;
+};
+
+const useProgramLayoutTemplate = (id: string) => {
+  const {
+    loading: layoutTemplateLoading,
+    error,
+    data,
+  } = useQuery(GetProgramTemplateLayoutFormAndValue, {
+    variables: { id },
+  });
+
+  // Ensure data is present and has the expected structure
+  const rawLayoutTemplateDefinition = data?.program_layout_template_config?.length
+    ? (first(data.program_layout_template_config) as any).program_layout_template
+    : null;
+  const rawLayoutTemplateFormValue = data?.program_layout_template_config?.length
+    ? first(data.program_layout_template_config) as any
+    : null;
+
+  const customAttributesDefinitions: LayoutTemplateCustomAttribute | null = rawLayoutTemplateDefinition
+    ? {
+        id: rawLayoutTemplateDefinition.id,
+        customAttributes: rawLayoutTemplateDefinition.module_name.map(
+          (v: { id: string; name: string; type: string }) => ({
+            id: v.id,
+            name: v.name,
+            type: v.type,
+          })
+        ),
+      }
+    : null;
+
+  const customAttributesFormValue: ProgramLayoutTemplateConfig | null = rawLayoutTemplateFormValue
+    ? {
+        id: rawLayoutTemplateFormValue.id,
+        customAttributeValue: rawLayoutTemplateFormValue.module_data as Record<string, any>,
+      }
+    : null;
+
+  return { layoutTemplateLoading, error, customAttributesDefinitions, customAttributesFormValue };
+};
+
+export default useProgramLayoutTemplate;

--- a/src/hooks/programLayoutTemplate.ts
+++ b/src/hooks/programLayoutTemplate.ts
@@ -1,5 +1,6 @@
-import { useQuery, gql } from '@apollo/client';
+import { useQuery, gql, useMutation } from '@apollo/client';
 import { first } from 'lodash';
+import moment, { MomentInput } from 'moment';
 
 const GetProgramTemplateLayoutFormAndValue = gql`
   query GetProgramTemplateLayoutFormAndValue($id: uuid!) {
@@ -14,10 +15,29 @@ const GetProgramTemplateLayoutFormAndValue = gql`
   }
 `;
 
+const UpdateTemplateCustomAttributeFormValue = gql`
+  mutation UpdateTemplateCustomAttributeFormValue(
+    $programId: uuid!,
+    $programLayoutTemplateConfigId: uuid!,
+    $moduleData: jsonb!
+  ) {
+    update_program_layout_template_config(
+      where: {
+        program_id: { _eq: $programId },
+        id: { _eq: $programLayoutTemplateConfigId },
+        is_active: { _eq: true }
+      },
+      _set: { module_data: $moduleData }
+    ) {
+      affected_rows
+    }
+  }
+`
+
 type CustomAttribute = {
   id: string;
   name: string;
-  type: string;
+  type: "Number" | "Date" | "Text";
 };
 
 type LayoutTemplateCustomAttribute = {
@@ -30,16 +50,16 @@ type ProgramLayoutTemplateConfig = {
   customAttributeValue: Record<string, any>;
 };
 
-const useProgramLayoutTemplate = (id: string) => {
+export const useProgramLayoutTemplate = (id: string) => {
   const {
     loading: layoutTemplateLoading,
     error,
     data,
+    refetch
   } = useQuery(GetProgramTemplateLayoutFormAndValue, {
     variables: { id },
   });
 
-  // Ensure data is present and has the expected structure
   const rawLayoutTemplateDefinition = data?.program_layout_template_config?.length
     ? (first(data.program_layout_template_config) as any).program_layout_template
     : null;
@@ -47,27 +67,63 @@ const useProgramLayoutTemplate = (id: string) => {
     ? first(data.program_layout_template_config) as any
     : null;
 
-  const customAttributesDefinitions: LayoutTemplateCustomAttribute | null = rawLayoutTemplateDefinition
+    const customAttributesDefinitions: LayoutTemplateCustomAttribute | null = rawLayoutTemplateDefinition
     ? {
         id: rawLayoutTemplateDefinition.id,
-        customAttributes: rawLayoutTemplateDefinition.module_name.map(
-          (v: { id: string; name: string; type: string }) => ({
-            id: v.id,
-            name: v.name,
-            type: v.type,
-          })
-        ),
+        customAttributes: rawLayoutTemplateDefinition.module_name.map((v: { id: string; name: string; type: string }) => ({
+          id: v.id,
+          name: v.name,
+          type: v.type === 'Number' || v.type === 'Date' || v.type === 'Text' ? v.type : 'Text',
+        })),
       }
     : null;
+    
+    const isMomentInput = (value: any): value is MomentInput => {
+      return moment(value).isValid();
+    };
+    
+    const customAttributesFormValue: ProgramLayoutTemplateConfig | null = rawLayoutTemplateFormValue
+      ? {
+          id: rawLayoutTemplateFormValue.id,
+          customAttributeValue: Object.fromEntries(
+            Object.entries(rawLayoutTemplateFormValue.module_data).map(([key, value]) => {
+              const attributeDefinition = customAttributesDefinitions?.customAttributes.find(attr => attr.id === key);
+              if (attributeDefinition && attributeDefinition.type === 'Date' && isMomentInput(value)) {
+                return [key, moment(value)];
+              }
+              return [key, value];
+            })
+          ),
+        }
+      : null;
+    
+  
 
-  const customAttributesFormValue: ProgramLayoutTemplateConfig | null = rawLayoutTemplateFormValue
-    ? {
-        id: rawLayoutTemplateFormValue.id,
-        customAttributeValue: rawLayoutTemplateFormValue.module_data as Record<string, any>,
-      }
-    : null;
-
-  return { layoutTemplateLoading, error, customAttributesDefinitions, customAttributesFormValue };
+  return { layoutTemplateLoading, error, customAttributesDefinitions, customAttributesFormValue, refetchLayoutTemplate: refetch };
 };
 
-export default useProgramLayoutTemplate;
+
+export const useUpdateCustomAttributeFormValue = (programId: string, programLayoutTemplateConfigId: string) => {
+  const [updateCustomAttributesValueGql, { loading, error, data }] = useMutation(
+    UpdateTemplateCustomAttributeFormValue
+  );
+
+  const updateCustomAttributesValue = async (moduleData: Record<string, any>) => {
+    try {
+      const response = await updateCustomAttributesValueGql({
+        variables: {
+          programId,
+          programLayoutTemplateConfigId,
+          moduleData,
+        },
+      });
+      return response;
+    } catch (err) {
+      console.error(err);
+      throw err;
+    }
+  };
+
+  return { updateCustomAttributesValue, loading, error, data };
+};
+

--- a/src/hooks/programLayoutTemplate.ts
+++ b/src/hooks/programLayoutTemplate.ts
@@ -100,6 +100,7 @@ export const useActivatedTemplateForProgram = () => {
           programId,
           programLayoutTemplateId,
         },
+        fetchPolicy: 'network-only',
       });
   
       const existConfigId = data?.program_layout_template_config?.[0]?.id;

--- a/src/pages/ProgramAdminPage/ProgramAdditionalSettingsForm.tsx
+++ b/src/pages/ProgramAdminPage/ProgramAdditionalSettingsForm.tsx
@@ -6,7 +6,7 @@ import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
 import styled from 'styled-components'
 import { useUpdateCustomAttributeFormValue } from '../../hooks/programLayoutTemplate'
-import { ModuleDataType, ProgramAdminProps } from '../../types/program'
+import { ProgramAdminProps } from '../../types/program'
 import ProgramAdminPageMessages from './translation'
 
 const StyledDatePicker = styled(DatePicker)<DatePickerProps>`
@@ -68,7 +68,7 @@ class RenderStrategyContext {
   }
 }
 
-type FieldProps = {} & ModuleDataType
+type FieldProps = {}
 
 const ProgramAdditionalSettingsForm: React.FC<{
   programId: string
@@ -76,7 +76,7 @@ const ProgramAdditionalSettingsForm: React.FC<{
   program: ProgramAdminProps | null
   onRefetch?: () => void
 }> = ({ programId, programLayoutTemplateConfigId, program, onRefetch }) => {
-  const customAttrDefination = program?.programLayoutTemplateConfig?.ProgramLayoutTemplate || {
+  const customAttrDefinition = program?.programLayoutTemplateConfig?.ProgramLayoutTemplate || {
     id: 'notFoundCustomAttr',
     customAttribute: null,
   }
@@ -92,7 +92,7 @@ const ProgramAdditionalSettingsForm: React.FC<{
         id: program?.programLayoutTemplateConfig?.id,
         customAttributeValue: Object.fromEntries(
           Object.entries(program?.programLayoutTemplateConfig?.moduleData).map(([key, value]) => {
-            const attributeDefinition = customAttrDefination?.customAttribute?.find(attr => attr.id === key)
+            const attributeDefinition = customAttrDefinition?.customAttribute?.find(attr => attr.id === key)
             if (attributeDefinition && attributeDefinition.type === 'Date' && isMomentInput(value)) {
               return [key, moment(value)]
             }
@@ -130,8 +130,8 @@ const ProgramAdditionalSettingsForm: React.FC<{
       onFinish={handleSubmit}
       initialValues={customAttributesValue?.customAttributeValue}
     >
-      {customAttrDefination &&
-        customAttrDefination.customAttribute?.map(v => {
+      {customAttrDefinition &&
+        customAttrDefinition.customAttribute?.map(v => {
           return (
             <Form.Item key={v.id} label={v.name} name={v.id}>
               {renderContext.renderModuleComponent(v.type)}

--- a/src/pages/ProgramAdminPage/ProgramAdditionalSettingsForm.tsx
+++ b/src/pages/ProgramAdminPage/ProgramAdditionalSettingsForm.tsx
@@ -78,7 +78,7 @@ const ProgramAdditionalSettingsForm: React.FC<{
 }> = ({ programId, programLayoutTemplateConfigId, program, onRefetch }) => {
   const customAttrDefinition = program?.programLayoutTemplateConfig?.ProgramLayoutTemplate || {
     id: 'notFoundCustomAttr',
-    customAttribute: null,
+    customAttributes: null,
   }
 
   const renderContext = new RenderStrategyContext()
@@ -92,7 +92,7 @@ const ProgramAdditionalSettingsForm: React.FC<{
         id: program?.programLayoutTemplateConfig?.id,
         customAttributeValue: Object.fromEntries(
           Object.entries(program?.programLayoutTemplateConfig?.moduleData).map(([key, value]) => {
-            const attributeDefinition = customAttrDefinition?.customAttribute?.find(attr => attr.id === key)
+            const attributeDefinition = customAttrDefinition?.customAttributes?.find(attr => attr.id === key)
             if (attributeDefinition && attributeDefinition.type === 'Date' && isMomentInput(value)) {
               return [key, moment(value)]
             }
@@ -131,7 +131,7 @@ const ProgramAdditionalSettingsForm: React.FC<{
       initialValues={customAttributesValue?.customAttributeValue}
     >
       {customAttrDefinition &&
-        customAttrDefinition.customAttribute?.map(v => {
+        customAttrDefinition.customAttributes?.map(v => {
           return (
             <Form.Item key={v.id} label={v.name} name={v.id}>
               {renderContext.renderModuleComponent(v.type)}

--- a/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
+++ b/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
@@ -106,7 +106,10 @@ const ProgramAdminPage: React.FC = () => {
               {isShowProgramAdditionalSettingsForm ? (
                 <AdminBlock>
                   <AdminBlockTitle>{formatMessage(ProgramAdminPageMessages['*'].otherSettings)}</AdminBlockTitle>
-                  <ProgramAdditionalSettingsForm programLayoutTemplateConfig={program?.programLayoutTemplateConfig} />
+                  <ProgramAdditionalSettingsForm
+                    programId={program?.id as string}
+                    programLayoutTemplateConfigId={program?.programLayoutTemplateConfig?.id as string}
+                  />
                 </AdminBlock>
               ) : null}
 

--- a/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
+++ b/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
@@ -108,6 +108,7 @@ const ProgramAdminPage: React.FC = () => {
                   <AdminBlockTitle>{formatMessage(ProgramAdminPageMessages['*'].otherSettings)}</AdminBlockTitle>
                   <ProgramAdditionalSettingsForm
                     programId={program?.id as string}
+                    program={program}
                     programLayoutTemplateConfigId={program?.programLayoutTemplateConfig?.id as string}
                   />
                 </AdminBlock>

--- a/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
+++ b/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
@@ -43,8 +43,8 @@ const ProgramAdminPage: React.FC = () => {
   const { program, refetchProgram } = useProgram(programId)
   const { updateProgramMetaTag } = useMutateProgram()
   const isShowProgramAdditionalSettingsForm =
-    Boolean(program?.programLayoutTemplateConfig?.moduleData) &&
-    !isEmpty(program?.programLayoutTemplateConfig?.moduleData) &&
+    Boolean(program?.programLayoutTemplateConfig?.isActive) &&
+    !isEmpty(program?.programLayoutTemplateConfig?.ProgramLayoutTemplate?.customAttribute) &&
     enabledModules?.program_layout_template
 
   return (

--- a/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
+++ b/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
@@ -43,7 +43,7 @@ const ProgramAdminPage: React.FC = () => {
   const { program, refetchProgram } = useProgram(programId)
   const { updateProgramMetaTag } = useMutateProgram()
   const isShowProgramAdditionalSettingsForm =
-    Boolean(program?.programLayoutTemplateConfig?.isActive) &&
+    program?.programLayoutTemplateConfig &&
     !isEmpty(program?.programLayoutTemplateConfig?.ProgramLayoutTemplate?.customAttribute) &&
     enabledModules?.program_layout_template
 

--- a/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
+++ b/src/pages/ProgramAdminPage/ProgramAdminPage.tsx
@@ -44,7 +44,7 @@ const ProgramAdminPage: React.FC = () => {
   const { updateProgramMetaTag } = useMutateProgram()
   const isShowProgramAdditionalSettingsForm =
     program?.programLayoutTemplateConfig &&
-    !isEmpty(program?.programLayoutTemplateConfig?.ProgramLayoutTemplate?.customAttribute) &&
+    !isEmpty(program?.programLayoutTemplateConfig?.ProgramLayoutTemplate?.customAttributes) &&
     enabledModules?.program_layout_template
 
   return (

--- a/src/pages/ProgramAdminPage/ProgramBasicForm.tsx
+++ b/src/pages/ProgramAdminPage/ProgramBasicForm.tsx
@@ -43,7 +43,6 @@ const ProgramBasicForm: React.FC<{
   const { programLayoutTemplates } = useGetProgramLayoutTemplates()
   const currentProgramLayoutTemplateId = program?.programLayoutTemplateConfig?.ProgramLayoutTemplate?.id
   const [updateProgramBasic] = useMutation(UPDATE_PROGRAM_BASIC)
-  // const [activateTemplateForProgram] = useMutation(ActivateTemplateForProgram)
   const { activatedTemplateForProgram } = useActivatedTemplateForProgram()
 
   if (!program || loadingProduct) {

--- a/src/pages/ProgramCollectionAdminPage.tsx
+++ b/src/pages/ProgramCollectionAdminPage.tsx
@@ -17,6 +17,7 @@ import ProgramAdminCard from '../components/program/ProgramAdminCard'
 import hasura from '../hasura'
 import { handleError } from '../helpers'
 import { commonMessages, programMessages } from '../helpers/translation'
+import { useActivatedTemplateForProgram } from '../hooks/programLayoutTemplate'
 import { ProgramPlanPeriodType, ProgramPreviewProps } from '../types/program'
 import ForbiddenPage from './ForbiddenPage'
 import LoadingPage from './LoadingPage'
@@ -53,6 +54,7 @@ const ProgramCollectionAdminPage: React.FC = () => {
     hasura.InsertProgramLayoutTemplateConfig,
     hasura.InsertProgramLayoutTemplateConfigVariables
   >(InsertProgramLayoutTemplateConfig)
+  const { activatedTemplateForProgram } = useActivatedTemplateForProgram()
 
   if (!permissions.PROGRAM_ADMIN && !permissions.PROGRAM_NORMAL) {
     return <ForbiddenPage />
@@ -159,14 +161,7 @@ const ProgramCollectionAdminPage: React.FC = () => {
                 },
               }).then(async res => {
                 const programId = res.data?.insert_program?.returning[0]?.id
-                programLayoutTemplateId &&
-                  (await insertProgramLayoutTemplateConfig({
-                    variables: {
-                      programId,
-                      programLayoutTemplateId: programLayoutTemplateId,
-                      moduleData: null,
-                    },
-                  }))
+                programLayoutTemplateId && (await activatedTemplateForProgram(programId, programLayoutTemplateId))
                 programId && history.push(`/programs/${programId}`)
               })
             }

--- a/src/pages/ProgramCollectionAdminPage.tsx
+++ b/src/pages/ProgramCollectionAdminPage.tsx
@@ -50,10 +50,6 @@ const ProgramCollectionAdminPage: React.FC = () => {
   const [counts, setCounts] = useState<{ [key: string]: number }>({})
 
   const [insertProgram] = useMutation<hasura.INSERT_PROGRAM, hasura.INSERT_PROGRAMVariables>(INSERT_PROGRAM)
-  const [insertProgramLayoutTemplateConfig] = useMutation<
-    hasura.InsertProgramLayoutTemplateConfig,
-    hasura.InsertProgramLayoutTemplateConfigVariables
-  >(InsertProgramLayoutTemplateConfig)
   const { activatedTemplateForProgram } = useActivatedTemplateForProgram()
 
   if (!permissions.PROGRAM_ADMIN && !permissions.PROGRAM_NORMAL) {
@@ -540,22 +536,6 @@ const UPDATE_PROGRAM_POSITION_COLLECTION = gql`
   mutation UPDATE_PROGRAM_POSITION_COLLECTION($data: [program_insert_input!]!) {
     insert_program(objects: $data, on_conflict: { constraint: program_pkey, update_columns: position }) {
       affected_rows
-    }
-  }
-`
-
-const InsertProgramLayoutTemplateConfig = gql`
-  mutation InsertProgramLayoutTemplateConfig($programId: uuid!, $programLayoutTemplateId: uuid!, $moduleData: jsonb!) {
-    insert_program_layout_template_config(
-      objects: {
-        program_id: $programId
-        program_layout_template_id: $programLayoutTemplateId
-        module_data: $moduleData
-      }
-    ) {
-      returning {
-        id
-      }
     }
   }
 `

--- a/src/pages/ProgramCollectionAdminPage.tsx
+++ b/src/pages/ProgramCollectionAdminPage.tsx
@@ -144,7 +144,7 @@ const ProgramCollectionAdminPage: React.FC = () => {
             withCreatorSelector={currentUserRole === 'app-owner'}
             withProgramType
             withProgramLayoutTemplateType={enabledModules?.program_layout_template}
-            onCreate={({ title, categoryIds, creatorId, programLayoutTemplateData }) =>
+            onCreate={({ title, categoryIds, creatorId, programLayoutTemplateId }) =>
               insertProgram({
                 variables: {
                   ownerId: currentMemberId,
@@ -159,14 +159,12 @@ const ProgramCollectionAdminPage: React.FC = () => {
                 },
               }).then(async res => {
                 const programId = res.data?.insert_program?.returning[0]?.id
-                programLayoutTemplateData?.id &&
+                programLayoutTemplateId &&
                   (await insertProgramLayoutTemplateConfig({
                     variables: {
                       programId,
-                      programLayoutTemplateId: programLayoutTemplateData?.id,
-                      moduleData: {
-                        ...programLayoutTemplateData?.moduleData,
-                      },
+                      programLayoutTemplateId: programLayoutTemplateId,
+                      moduleData: null,
                     },
                   }))
                 programId && history.push(`/programs/${programId}`)

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -285,7 +285,7 @@ export type ProgramLayoutTemplate = {
   customAttribute: {
     id: string
     name: string
-    type: string
+    type: "Number" | "Date" | "Text" | 'TextEditor'
   }[]
 }
 

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -243,7 +243,7 @@ export type Media = 'video' | 'image'
 
 export type ProgramLayoutTemplate = {
   id: string
-  customAttribute: {
+  customAttributes: {
     id: string
     name: string
     type: 'Number' | 'Date' | 'Text' | 'TextEditor'

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -60,7 +60,7 @@ export type ProgramAdminProps = ProgramProps & {
   categories: Category[]
   tags: string[]
   approvals: ProgramApprovalProps[]
-  programLayoutTemplateConfig?: ProgramLayoutTemplateConfig
+  programLayoutTemplateConfig?: ProgramLayoutTemplateConfig | null
 }
 
 export type ProgramContentSectionProps = {
@@ -294,7 +294,6 @@ export type ProgramLayoutTemplateConfig = {
   programId: string
   programLayoutTemplateId: string
   moduleData: ModuleDataProps
-  isActive: boolean
   ProgramLayoutTemplate?: ProgramLayoutTemplate | null
 }
 

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -281,10 +281,12 @@ export interface ModuleDataProps {
 }
 
 export type ProgramLayoutTemplate = {
-  id: string
-  name: string
-  moduleData?: ModuleDataProps | null
-  // ProgramLayoutTemplate?: object
+  id: string,
+  customAttribute: {
+    id: string
+    name: string
+    type: string
+  }[]
 }
 
 export type ProgramLayoutTemplateConfig = {
@@ -293,7 +295,7 @@ export type ProgramLayoutTemplateConfig = {
   programLayoutTemplateId: string
   moduleData: ModuleDataProps
   isActive: boolean
-  ProgramLayoutTemplate?: ProgramLayoutTemplate
+  ProgramLayoutTemplate?: ProgramLayoutTemplate | null
 }
 
 export type ExtractModuleDataValue<T> = T extends infer V ? V : never

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -241,51 +241,12 @@ export type Exam = {
 
 export type Media = 'video' | 'image'
 
-export enum LayoutTemplateModuleType {
-  DATE = 'Date',
-  NUMBER = 'Number',
-}
-
-export enum LayoutTemplateModuleName {
-  EXPECTED_START_DATE = 'expectedStartDate',
-  EXPECTED_DURATION = 'expectedDuration',
-  EXPECTED_SECTIONS = 'expectedSections',
-  COMPLETED_RELEASE = 'completeRelease',
-}
-
-interface BaseModuleProps<T> {
-  id: string
-  type: T
-}
-
-interface ModuleNameTemplate<N, T> extends BaseModuleProps<T> {
-  name: N
-}
-
-interface ModuleDataTemplate<V, T> extends BaseModuleProps<T> {
-  value: V
-}
-
-export type ModuleNameProps = Array<
-  | ModuleNameTemplate<LayoutTemplateModuleName.EXPECTED_START_DATE, LayoutTemplateModuleType.DATE>
-  | ModuleNameTemplate<LayoutTemplateModuleName.EXPECTED_DURATION, LayoutTemplateModuleType.NUMBER>
-  | ModuleNameTemplate<LayoutTemplateModuleName.EXPECTED_SECTIONS, LayoutTemplateModuleType.NUMBER>
-  | ModuleNameTemplate<LayoutTemplateModuleName.COMPLETED_RELEASE, LayoutTemplateModuleType.DATE>
->
-
-export interface ModuleDataProps {
-  [LayoutTemplateModuleName.EXPECTED_START_DATE]?: ModuleDataTemplate<Date, LayoutTemplateModuleType.DATE>
-  [LayoutTemplateModuleName.EXPECTED_DURATION]?: ModuleDataTemplate<Number, LayoutTemplateModuleType.NUMBER>
-  [LayoutTemplateModuleName.EXPECTED_SECTIONS]?: ModuleDataTemplate<Number, LayoutTemplateModuleType.NUMBER>
-  [LayoutTemplateModuleName.COMPLETED_RELEASE]?: ModuleDataTemplate<Date, LayoutTemplateModuleType.DATE>
-}
-
 export type ProgramLayoutTemplate = {
-  id: string,
+  id: string
   customAttribute: {
     id: string
     name: string
-    type: "Number" | "Date" | "Text" | 'TextEditor'
+    type: 'Number' | 'Date' | 'Text' | 'TextEditor'
   }[]
 }
 
@@ -293,14 +254,6 @@ export type ProgramLayoutTemplateConfig = {
   id: string
   programId: string
   programLayoutTemplateId: string
-  moduleData: ModuleDataProps
+  moduleData: Record<string, any>
   ProgramLayoutTemplate?: ProgramLayoutTemplate | null
-}
-
-export type ExtractModuleDataValue<T> = T extends infer V ? V : never
-
-export type ExtractModuleDataValueType<T> = T extends { value: infer V } ? V : never
-
-export type ModuleDataType = {
-  [K in keyof ModuleDataProps]?: ExtractModuleDataValueType<ModuleDataProps[K]>
 }


### PR DESCRIPTION
# Challenges
- other settings are developed as specific features and cannot be extended
- The standard template depended on database data
--- 
##  1. create program
<img width="519" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107536598/e3aef80f-b9cf-49c7-a615-1c6c50a5fbc9">

### user story
As a user with permissions, when I click to create a course, I should be able to choose a template. The options should include the standard template as well as all registered templates
### refactor
- When a user with permissions chooses the standard template(標準版型) while creating a course, the selected ID should be set to null, and no data should be created in the program_layout_template_config table.
### commit 
-  [5544e26](https://github.com/urfit-tech/lodestar-app-admin/pull/532/commits/5544e2686fbb7f2087801d7caf17c95f0d516cd8)
- [acd2cab](https://github.com/urfit-tech/lodestar-app-admin/pull/532/commits/acd2cabf49204f06ee5771465a3218599ebe01d0)

## 2. show additional option form in program basic form

### user story 
When the user selects a non-standard template, an additional options form specific to that template should appear for the user to fill out

<img width="557" alt="image" src="https://github.com/urfit-tech/lodestar-app-admin/assets/107536598/70ef3da9-b679-482e-9293-ac7a3906812f">

## 3.  changing template 

### user story 
When the user switches the course back to the default template, the other settings forms will disappear. When the course is changed to a non-default template, the other settings should reappear with the values from the original form.

### refactor
record in used template in program activated_layout_template_config_id

