### PR TITLE
feat: ebook trial percentage setting

### DIFF
--- a/src/components/program/DisplayModeSelector.tsx
+++ b/src/components/program/DisplayModeSelector.tsx
@@ -1,7 +1,6 @@
 import { Flex } from '@chakra-ui/react'
 import { DatePicker, Form, Select } from 'antd'
 import moment from 'moment'
-import { useState } from 'react'
 import { useIntl } from 'react-intl'
 import programMessages from './translation'
 
@@ -10,14 +9,14 @@ export type DisplayMode = 'conceal' | 'trial' | 'loginToTrial' | 'payToWatch'
 const DisplayModeSelector: React.VFC<{
   contentType: string | null
   displayMode: DisplayMode
-}> = ({ contentType, displayMode }) => {
+  onDisplayModeChange: (displayMode: DisplayMode) => void
+}> = ({ contentType, displayMode, onDisplayModeChange }) => {
   const { formatMessage } = useIntl()
-  const [currentOption, setCurrentOption] = useState<DisplayMode>(displayMode)
 
   return (
     <Flex flexWrap="wrap" gridGap="2">
       <Form.Item name="displayMode" className="mb-0">
-        <Select style={{ width: '120px' }} onChange={(v: DisplayMode) => setCurrentOption(v)}>
+        <Select style={{ width: '120px' }} onChange={(v: DisplayMode) => onDisplayModeChange(v)}>
           <Select.Option key="conceal" value="conceal">
             {formatMessage(programMessages.DisplayModeSelector.conceal)}
           </Select.Option>
@@ -48,7 +47,7 @@ const DisplayModeSelector: React.VFC<{
           </Select.Option>
         </Select>
       </Form.Item>
-      {currentOption === 'payToWatch' && (
+      {displayMode === 'payToWatch' && (
         <Form.Item name="publishedAt" className="mb-0 mr-2">
           <DatePicker
             format="YYYY-MM-DD HH:mm"

--- a/src/components/program/ExerciseAdminModalBlock.tsx
+++ b/src/components/program/ExerciseAdminModalBlock.tsx
@@ -12,7 +12,7 @@ import hasura from '../../hasura'
 import { handleError } from '../../helpers'
 import { useMutateProgramContent, useProgramContentActions } from '../../hooks/program'
 import { Exam, ExamTimeUnit, ProgramContentProps } from '../../types/program'
-import DisplayModeSelector from './DisplayModeSelector'
+import DisplayModeSelector, { DisplayMode } from './DisplayModeSelector'
 import ExamBasicForm from './ExamBasicForm'
 import ExamQuestionSettingForm from './ExamQuestionSettingForm'
 import programMessages from './translation'
@@ -244,9 +244,11 @@ const UPDATE_EXAM_PROGRAM_CONTENT = gql`
 const ExerciseAdminModalBlock: React.FC<{
   programId: string
   programContent: ProgramContentProps
+  displayMode: DisplayMode
+  onDisplayModeChange: (displayMode: DisplayMode) => void
   onRefetch?: () => void
   onClose: () => void
-}> = ({ programId, programContent, onRefetch, onClose }) => {
+}> = ({ programId, programContent, displayMode, onDisplayModeChange, onRefetch, onClose }) => {
   const { formatMessage } = useIntl()
   const [form] = useForm<FieldProps>()
   const { deleteProgramContentExerciseAndExam } = useMutateProgramContent()
@@ -545,9 +547,13 @@ const ExerciseAdminModalBlock: React.FC<{
         marginBottom="16px"
         flexDirection={{ base: 'column-reverse', md: 'row' }}
       >
-        <Flex flexWrap="wrap">
+        <Flex flexWrap="wrap" gridGap="2">
           {programContent.displayMode && (
-            <DisplayModeSelector contentType="exam" displayMode={programContent.displayMode} />
+            <DisplayModeSelector
+              contentType="exam"
+              displayMode={displayMode}
+              onDisplayModeChange={onDisplayModeChange}
+            />
           )}
           <Form.Item name="isNotifyUpdate" valuePropName="checked" className="mb-0">
             <Checkbox className="mr-2">{formatMessage(programMessages['*'].notifyUpdate)}</Checkbox>

--- a/src/components/program/PracticeAdminModalBlock.tsx
+++ b/src/components/program/PracticeAdminModalBlock.tsx
@@ -18,7 +18,7 @@ import { StyledTips } from '../admin'
 import FileUploader from '../common/FileUploader'
 import RatingInput from '../common/RatingInput'
 import AdminBraftEditor from '../form/AdminBraftEditor'
-import DisplayModeSelector from './DisplayModeSelector'
+import DisplayModeSelector, { DisplayMode } from './DisplayModeSelector'
 import ProgramPlanSelector from './ProgramPlanSelector'
 import programMessages from './translation'
 
@@ -59,9 +59,11 @@ const PracticeForm: React.FC<{
   programId: string
   programContent: ProgramContentProps
   programContentBody: ProgramContentBody
+  displayMode: DisplayMode
+  onDisplayModeChange: (displayMode: DisplayMode) => void
   onRefetch?: () => void
   onCancel?: () => void
-}> = ({ programId, programContent, programContentBody, onRefetch, onCancel }) => {
+}> = ({ programId, programContent, programContentBody, displayMode, onDisplayModeChange, onRefetch, onCancel }) => {
   const { formatMessage } = useIntl()
   const [form] = useForm<FieldProps>()
   const uploadAttachments = useUploadAttachments()
@@ -166,9 +168,13 @@ const PracticeForm: React.FC<{
         marginBottom="16px"
         flexDirection={{ base: 'column-reverse', md: 'row' }}
       >
-        <Flex flexWrap="wrap">
+        <Flex flexWrap="wrap" gridGap="2">
           {programContent.displayMode && (
-            <DisplayModeSelector contentType="practice" displayMode={programContent.displayMode} />
+            <DisplayModeSelector
+              contentType="practice"
+              displayMode={displayMode}
+              onDisplayModeChange={onDisplayModeChange}
+            />
           )}
           <Flex flexWrap="wrap">
             <Form.Item name="isPracticePrivate" valuePropName="checked" className="mr-3 mb-0">
@@ -325,9 +331,11 @@ const UPDATE_PRACTICE = gql`
 const PracticeAdminModalBlock: React.FC<{
   programId: string
   programContent: ProgramContentProps
+  displayMode: DisplayMode
+  onDisplayModeChange: (displayMode: DisplayMode) => void
   onRefetch?: () => void
   onClose: () => void
-}> = ({ programId, programContent, onRefetch, onClose }) => {
+}> = ({ programId, programContent, displayMode, onDisplayModeChange, onRefetch, onClose }) => {
   const { loadingProgramContentBody, programContentBody } = useProgramContentBody(programContent.id)
 
   if (loadingProgramContentBody) return <Skeleton active />
@@ -336,6 +344,8 @@ const PracticeAdminModalBlock: React.FC<{
       programId={programId}
       programContent={programContent}
       programContentBody={programContentBody}
+      displayMode={displayMode}
+      onDisplayModeChange={onDisplayModeChange}
       onRefetch={() => onRefetch?.()}
       onCancel={() => onClose()}
     />

--- a/src/components/program/translation.ts
+++ b/src/components/program/translation.ts
@@ -102,6 +102,10 @@ const programMessages = {
       id: 'program.ProgramContentAdminModal.uploadEbookFileTips',
       defaultMessage: '只接受符合 EPUB 3 格式檔案',
     },
+    ebookTrialPercentageSetting: {
+      id: 'program.ProgramContentAdminModal.ebookTrialPercentageSetting',
+      defaultMessage: 'Trial Percentage Setting',
+    },
     audioFileTips: {
       id: 'program.ProgramContentAdminModal.audioFileTips',
       defaultMessage: 'Accept format: .mp3\nFile size: 250MB',

--- a/src/hooks/ebook.ts
+++ b/src/hooks/ebook.ts
@@ -11,10 +11,22 @@ export const useMutateProgramContentEbook = () => {
         insert_program_content_ebook_one(object: $programContentEbook) {
           program_content_id
           data
+          trial_percentage
         }
       }
     `,
   )
+
+  const [updateProgramContentEbook] = useMutation(gql`
+    mutation UpdateProgramContentEBook($programContentId: uuid!, $trialPercentage: Int) {
+      update_program_content_ebook(
+        where: { program_content_id: { _eq: $programContentId } }
+        _set: { trial_percentage: $trialPercentage }
+      ) {
+        affected_rows
+      }
+    }
+  `)
 
   const [deleteProgramContentEbook] = useMutation<
     hasura.DeleteProgramContentEbook,
@@ -53,6 +65,7 @@ export const useMutateProgramContentEbook = () => {
 
   return {
     insertProgramContentEbook,
+    updateProgramContentEbook,
     deleteProgramContentEbook,
     deleteProgramContentEbookToc,
     deleteProgramContentEbookTocProgress,

--- a/src/hooks/program.ts
+++ b/src/hooks/program.ts
@@ -97,6 +97,7 @@ export const useProgram = (programId: string) => {
               program_content_ebook {
                 id
                 data
+                trial_percentage
               }
             }
           }
@@ -236,7 +237,11 @@ export const useProgram = (programId: string) => {
             data: pca.data,
           })),
           ebook: pc.program_content_ebook
-            ? { id: pc.program_content_ebook.id, data: pc.program_content_ebook.data }
+            ? {
+                id: pc.program_content_ebook.id,
+                data: pc.program_content_ebook.data,
+                trialPercentage: pc.program_content_ebook.trial_percentage,
+              }
             : null,
         })),
         collapsed_status: pcs.collapsed_status || false,

--- a/src/translations/locales/en-us.json
+++ b/src/translations/locales/en-us.json
@@ -2384,6 +2384,7 @@
   "program.ProgramContentAdminModal.deleteContentWarning": "你確定要刪除此內容？此動作無法還原",
   "program.ProgramContentAdminModal.duration": "內容時長（分鐘）",
   "program.ProgramContentAdminModal.ebookFile": "電子書檔案",
+  "program.ProgramContentAdminModal.ebookTrialPercentageSetting": "Trial Percentage Setting",
   "program.ProgramContentAdminModal.uploadCaption": "上傳字幕",
   "program.ProgramContentAdminModal.uploadEbookFileTips": "只接受符合 EPUB 3 格式檔案",
   "program.ProgramContentAdminModal.uploadFile": "上傳檔案",

--- a/src/translations/locales/id.json
+++ b/src/translations/locales/id.json
@@ -2384,6 +2384,7 @@
   "program.ProgramContentAdminModal.deleteContentWarning": "你確定要刪除此內容？此動作無法還原",
   "program.ProgramContentAdminModal.duration": "內容時長（分鐘）",
   "program.ProgramContentAdminModal.ebookFile": "電子書檔案",
+  "program.ProgramContentAdminModal.ebookTrialPercentageSetting": "Mengatur pembacaan percobaan",
   "program.ProgramContentAdminModal.uploadCaption": "上傳字幕",
   "program.ProgramContentAdminModal.uploadEbookFileTips": "只接受符合 EPUB 3 格式檔案",
   "program.ProgramContentAdminModal.uploadFile": "上傳檔案",

--- a/src/translations/locales/vi.json
+++ b/src/translations/locales/vi.json
@@ -2384,6 +2384,7 @@
   "program.ProgramContentAdminModal.deleteContentWarning": "你確定要刪除此內容？此動作無法還原",
   "program.ProgramContentAdminModal.duration": "內容時長（分鐘）",
   "program.ProgramContentAdminModal.ebookFile": "電子書檔案",
+  "program.ProgramContentAdminModal.ebookTrialPercentageSetting": "Thiết lập chế độ đọc thử",
   "program.ProgramContentAdminModal.uploadCaption": "上傳字幕",
   "program.ProgramContentAdminModal.uploadEbookFileTips": "只接受符合 EPUB 3 格式檔案",
   "program.ProgramContentAdminModal.uploadFile": "上傳檔案",

--- a/src/translations/locales/zh-cn.json
+++ b/src/translations/locales/zh-cn.json
@@ -2384,6 +2384,7 @@
   "program.ProgramContentAdminModal.deleteContentWarning": "你確定要刪除此內容？此動作無法還原",
   "program.ProgramContentAdminModal.duration": "內容時長（分鐘）",
   "program.ProgramContentAdminModal.ebookFile": "電子書檔案",
+  "program.ProgramContentAdminModal.ebookTrialPercentageSetting": "设定试阅",
   "program.ProgramContentAdminModal.uploadCaption": "上傳字幕",
   "program.ProgramContentAdminModal.uploadEbookFileTips": "只接受符合 EPUB 3 格式檔案",
   "program.ProgramContentAdminModal.uploadFile": "上傳檔案",

--- a/src/translations/locales/zh-tw.json
+++ b/src/translations/locales/zh-tw.json
@@ -2388,6 +2388,7 @@
   "program.ProgramContentAdminModal.deleteContentWarning": "你確定要刪除此內容？此動作無法還原",
   "program.ProgramContentAdminModal.duration": "內容時長（分鐘）",
   "program.ProgramContentAdminModal.ebookFile": "電子書檔案",
+  "program.ProgramContentAdminModal.ebookTrialPercentageSetting": "設定試閱",
   "program.ProgramContentAdminModal.uploadCaption": "上傳字幕",
   "program.ProgramContentAdminModal.uploadEbookFileTips": "只接受符合 EPUB 3 格式檔案",
   "program.ProgramContentAdminModal.uploadFile": "上傳檔案",

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -119,6 +119,7 @@ export type ProgramContentProps = {
   ebook: {
     id: string
     data: any
+    trialPercentage: number
   } | null
   programContentBodyData: any
   displayMode: DisplayMode
@@ -302,4 +303,3 @@ export type ExtractModuleDataValueType<T> = T extends { value: infer V } ? V : n
 export type ModuleDataType = {
   [K in keyof ModuleDataProps]?: ExtractModuleDataValueType<ModuleDataProps[K]>
 }
-


### PR DESCRIPTION
# 先合併至 https://github.com/urfit-tech/lodestar-app-admin/pull/531

# WHY

# WHAT
- Move the option state of DisplayModeSelector to the parent component, because the changed state of displayMode needs to be used to determine whether the trialPercentage field appears.
- Determine the progress of e-book trial reading through the trialPercentage field.
- Determine the default value of trial reading through ebookTrialPercentageSetting of app_setting.