### PR TITLE
feat: remove deposit and balance payment mode

### DIFF
--- a/src/pages/NewMemberContractCreationPage/MemberContractCreationBlock.tsx
+++ b/src/pages/NewMemberContractCreationPage/MemberContractCreationBlock.tsx
@@ -290,15 +290,11 @@ const MemberContractCreationBlock: React.FC<{
         ? 'physicalRemoteCredit'
         : undefined
 
-    const installmentPlans =
-      fieldValue.paymentMode === '訂金+尾款'
-        ? [
-            { price: Math.ceil(totalPrice * 0.1), index: 1 },
-            { price: totalPrice - Math.ceil(totalPrice * 0.1), index: 2 },
-          ]
-        : ['先上課後月結固定金額', '課前頭款+自訂分期', '開課後自訂分期'].includes(fieldValue.paymentMode)
-        ? installments
-        : undefined
+    const installmentPlans = ['先上課後月結固定金額', '課前頭款+自訂分期', '開課後自訂分期'].includes(
+      fieldValue.paymentMode,
+    )
+      ? installments
+      : undefined
     const paymentMode = fieldValue.paymentMode
     const invoiceInfo = {
       name: member.name,

--- a/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
+++ b/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
@@ -1540,7 +1540,6 @@ const MemberContractCreationForm: React.FC<
                 }}
               >
                 {paymentModes
-                  .filter(mode => (sum(selectedProducts.map(p => p.totalPrice)) >= 24000 ? true : mode !== '訂金+尾款'))
                   .filter(
                     mode =>
                       (!!isMemberTypeBG &&
@@ -1551,7 +1550,7 @@ const MemberContractCreationForm: React.FC<
                           '課前頭款+自訂分期',
                           '開課後自訂分期',
                         ].includes(mode)) ||
-                      (!isMemberTypeBG && ['全額付清', '訂金+尾款'].includes(mode)),
+                      (!isMemberTypeBG && ['全額付清'].includes(mode)),
                   )
                   .map((payment: string) => (
                     <Select.Option key={payment} value={payment}>

--- a/src/pages/NewMemberContractCreationPage/index.tsx
+++ b/src/pages/NewMemberContractCreationPage/index.tsx
@@ -19,7 +19,6 @@ import MemberDescriptionBlock from './MemberDescriptionBlock'
 const paymentMethods = ['藍新', '銀行匯款', '現金', '實體刷卡', '遠端輸入卡號'] as const
 const paymentModes = [
   '全額付清',
-  '訂金+尾款',
   '先上課後月結實支實付',
   '先上課後月結固定金額',
   '課前頭款+自訂分期',


### PR DESCRIPTION
移除訂金 + 尾款的付款模式，統一改為一次性付款

- 此改動移除了原有的「訂金＋尾款」付款邏輯，並將付款流程調整為單一筆款項完成支付。
- Trello 卡片：https://trello.com/c/l1zas0Wo