### PR TITLE
bugfix: execution date filter causes incorrect sort order

### DIFF
--- a/src/components/task/MemberTaskAdminBlock.tsx
+++ b/src/components/task/MemberTaskAdminBlock.tsx
@@ -492,8 +492,8 @@ const MemberTaskAdminBlock: React.FC<{
               type="primary"
               onClick={() => {
                 confirm()
+                setOrderBy({ due_at: 'desc' as hasura.order_by })
                 setFilter(filter => {
-                  setOrderBy({ due_at: 'desc' as hasura.order_by })
                   return {
                     ...filter,
                     dueAt: selectedKeys.length

--- a/src/components/task/MemberTaskAdminBlock.tsx
+++ b/src/components/task/MemberTaskAdminBlock.tsx
@@ -492,12 +492,15 @@ const MemberTaskAdminBlock: React.FC<{
               type="primary"
               onClick={() => {
                 confirm()
-                setFilter(filter => ({
-                  ...filter,
-                  dueAt: selectedKeys.length
-                    ? [moment(selectedKeys[0]).startOf('day').toDate(), moment(selectedKeys[1]).endOf('day').toDate()]
-                    : undefined,
-                }))
+                setFilter(filter => {
+                  setOrderBy({ due_at: 'desc' as hasura.order_by })
+                  return {
+                    ...filter,
+                    dueAt: selectedKeys.length
+                      ? [moment(selectedKeys[0]).startOf('day').toDate(), moment(selectedKeys[1]).endOf('day').toDate()]
+                      : undefined,
+                  }
+                })
               }}
               icon={<SearchOutlined />}
               size="small"

--- a/src/components/task/MemberTaskAdminBlock.tsx
+++ b/src/components/task/MemberTaskAdminBlock.tsx
@@ -138,7 +138,7 @@ const MemberTaskAdminBlock: React.FC<{
       setExcludedIds,
       ...filter,
       orderBy,
-      limit: display === 'table' ? 10 : undefined,
+      limit: display === 'table' ? 50 : undefined,
     })
 
   const groupList = Array.from(

--- a/src/hooks/task.ts
+++ b/src/hooks/task.ts
@@ -309,7 +309,7 @@ export const useMemberTaskCollection = (options?: {
     })) || []
 
   const loadMoreMemberTasks =
-    (data?.member_task_aggregate.aggregate?.count || 0) > (options?.limit || 0)
+    (data?.member_task_aggregate.aggregate?.count || 0) > (data?.member_task.length || 0)
       ? () =>
           fetchMore({
             variables: {

--- a/src/hooks/task.ts
+++ b/src/hooks/task.ts
@@ -142,6 +142,7 @@ export const useMemberTaskCollection = (options?: {
       query GET_MEMBER_TASK_COLLECTION(
         $condition: member_task_bool_exp
         $limit: Int
+        $offset: Int
         $orderBy: member_task_order_by!
         $propertyNames: [String!]
       ) {
@@ -182,7 +183,7 @@ export const useMemberTaskCollection = (options?: {
             count
           }
         }
-        member_task(where: $condition, limit: $limit, order_by: [$orderBy]) {
+        member_task(where: $condition, limit: $limit, offset: $offset, order_by: [$orderBy]) {
           id
           title
           description
@@ -315,15 +316,9 @@ export const useMemberTaskCollection = (options?: {
               orderBy,
               condition: {
                 ...condition,
-                id: { _nin: options?.excludedIds },
-                created_at: orderBy.created_at
-                  ? { [orderBy.created_at === 'desc' ? '_lt' : '_gt']: data?.member_task.slice(-1)[0]?.created_at }
-                  : undefined,
-                due_at: orderBy.due_at
-                  ? { [orderBy.due_at === 'desc' ? '_lt' : '_gt']: data?.member_task.slice(-1)[0]?.due_at }
-                  : undefined,
               },
               limit: options?.limit,
+              offset: data?.member_task.length || 0,
             },
             updateQuery: (prev, { fetchMoreResult }) => {
               if (!fetchMoreResult) {


### PR DESCRIPTION
篩選功能會影響排序邏輯，造成使用者無法正確依照『執行日期』查看最新項目。

修正後邏輯為：

- 篩選「執行日期」後，依照日期由新到舊排列（DESC）
- Trello 卡片：https://trello.com/c/AxzjK7b5