### PR TITLE
feat: control sales and contract access with permission groups

### DIFF
--- a/src/components/admin/AdminMenu.tsx
+++ b/src/components/admin/AdminMenu.tsx
@@ -58,6 +58,7 @@ const AdminMenu: React.FC<MenuProps & { opened?: boolean }> = ({ opened, childre
     permissions.GROSS_SALES_ADMIN,
     permissions.GROSS_SALES_NORMAL,
     permissions.SALES_RECORDS_ADMIN,
+    permissions.READ_GROUP_SALES_ALL,
     permissions.SALES_RECORDS_DETAILS,
     permissions.SALES_RECORDS_NORMAL,
   ].some(permission => permission)

--- a/src/components/form/translation.ts
+++ b/src/components/form/translation.ts
@@ -59,6 +59,7 @@ const formMessages = {
       id: 'form.PermissionGroup.MODIFY_MEMBER_PAYMENT_STATUS',
       defaultMessage: '調整會員交易狀態功能',
     },
+    READ_GROUP_SALES_ALL:{id: 'form.PermissionGroup.READ_GROUP_SALES_ALL', defaultMessage: '讀取組內資料' },
 
     // program
     PROGRAM_ADMIN: { id: 'form.PermissionGroup.PROGRAM_ADMIN', defaultMessage: '所有課程管理功能' },
@@ -336,6 +337,7 @@ const formMessages = {
       id: 'form.PermissionGroup.CONTRACT_RECOGNIZE_PERFORMANCE_EDIT',
       defaultMessage: '編輯績效金額',
     },
+    READ_GROUP_CONTRACT_ALL: { id: 'form.PermissionGroup.READ_GROUP_CONTRACT_ALL', defaultMessage: '讀取組內資料' },
 
     // craft
     CRAFT_PAGE_ADMIN: { id: 'form.PermissionGroup.CRAFT_PAGE_ADMIN', defaultMessage: '所有頁面模組功能' },

--- a/src/components/sale/SaleCollectionAdminCard.tsx
+++ b/src/components/sale/SaleCollectionAdminCard.tsx
@@ -68,6 +68,14 @@ const SaleCollectionAdminCard: React.VFC<{
   const [orderId, setOrderId] = useState<string | null>(null)
   const [memberNameAndEmail, setMemberNameAndEmail] = useState<string | null>(null)
 
+  const authStatus = permissions.SALES_RECORDS_ADMIN
+    ? 'Admin'
+    : permissions.READ_GROUP_SALES_ALL
+    ? 'Group'
+    : permissions.SALES_RECORDS_NORMAL
+    ? 'Personal'
+    : 'None'
+
   const {
     totalCount,
     loadingOrderLogPreviewCollection,
@@ -81,7 +89,7 @@ const SaleCollectionAdminCard: React.VFC<{
     loadMoreOrderLogPreviewCollection,
   } = useOrderLogPreviewCollection(
     permissions.CHECK_MEMBER_ORDER && memberId ? memberId : currentMemberId || '',
-    permissions.SALES_RECORDS_ADMIN ? 'Admin' : permissions.SALES_RECORDS_NORMAL ? 'Personal' : 'None',
+    authStatus,
     { statuses, orderId, memberNameAndEmail, memberId },
   )
 

--- a/src/hooks/order.ts
+++ b/src/hooks/order.ts
@@ -4,6 +4,7 @@ import hasura from '../hasura'
 import { sum, uniq } from 'ramda'
 import { OrderLog } from '../types/general'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
+import { useUserPermissionGroupMembers } from '../hooks/permission'
 
 export const useOrderStatuses = () => {
   const { loading, error, data } = useQuery<hasura.GET_ORDER_LOG_STATUS>(gql`
@@ -28,7 +29,7 @@ export const useOrderStatuses = () => {
 
 export const useOrderLogPreviewCollection = (
   memberId: string,
-  authStatus: 'Admin' | 'Personal' | 'None',
+  authStatus: 'Admin' |'Group'| 'Personal' | 'None',
   filters?: {
     statuses?: string[] | null
     orderId?: string | null
@@ -38,14 +39,21 @@ export const useOrderLogPreviewCollection = (
 ) => {
   const { id: appId } = useApp()
   const limit = 20
-  const condition: hasura.GetOrderLogPreviewCollectionVariables['condition'] = {
+  const conditionBase: hasura.GetOrderLogPreviewCollectionVariables['condition'] = {
     id: filters?.orderId ? { _ilike: `%${filters.orderId}%` } : undefined,
     app_id: appId ? { _eq: appId } : undefined,
-    status: filters?.statuses ? { _in: filters.statuses } : undefined,
-    member:
-      authStatus !== 'None'
-        ? filters?.memberId
-          ? { id: { _eq: filters.memberId } }
+    status: filters?.statuses ? { _in: filters.statuses } : undefined
+  }
+
+  const { permissionGroupsMembersOrderId } = useUserPermissionGroupMembers(memberId)
+
+  console.log('!!!!order 50!!!', permissionGroupsMembersOrderId)
+
+  let condition: hasura.GetOrderLogPreviewCollectionVariables['condition']
+  switch (authStatus) {
+    case 'Admin':
+       condition = {...conditionBase,
+        member: filters?.memberId? { id: { _eq: filters.memberId } }
           : filters?.memberNameAndEmail
           ? {
               _or: filters?.memberNameAndEmail
@@ -57,20 +65,42 @@ export const useOrderLogPreviewCollection = (
                 : undefined,
             }
           : undefined
-        : {
-            id: { _eq: memberId },
-          },
-    order_products:
-      authStatus === 'Personal'
-        ? {
-            product: {
-              product_owner: {
-                member_id: { _eq: memberId },
-              },
-            },
-          }
-        : undefined,
+        };
+      break;
+
+    case 'Personal':
+      condition = {...conditionBase,
+        order_products:
+          authStatus === 'Personal'
+            ? {
+                product: {
+                  product_owner: {
+                    member_id: { _eq: memberId },
+                  },
+                },
+              }
+            : undefined,
+      }
+      break
+
+    case 'Group':
+      condition = {...conditionBase,
+          id: { _in: permissionGroupsMembersOrderId },
+      }
+    break
+
+    default:
+      condition = {
+        ...conditionBase,
+        member: {
+          id: { _eq: memberId }
+        }
+      }
   }
+
+  console.log('!!!!order 102!!!', permissionGroupsMembersOrderId)
+  console.log('!!!!order 108!!!', authStatus)
+
   const {
     loading: loadingOrderLogPreviewCollection,
     error: errorOrderLogPreviewCollection,

--- a/src/hooks/permission.ts
+++ b/src/hooks/permission.ts
@@ -313,7 +313,8 @@ export const useMutationPermissionGroupAuditLog = () => {
   }
 }
 
-export const GetPermissionGroupMembers = gql`
+export const GetPermissionGroupMembers = 
+gql`
   query GetPermissionGroupMembers($permissionGroupId: uuid!) {
     member_permission_group(where: { permission_group_id: { _eq: $permissionGroupId } }) {
       member {
@@ -322,3 +323,62 @@ export const GetPermissionGroupMembers = gql`
     }
   }
 `
+
+export const useUserPermissionGroupMembers = (memberId: string) => {
+  const { loading, data } = useQuery<
+    hasura.GetUserPermissionGroupMembers,
+    hasura.GetUserPermissionGroupMembersVariables
+  >(
+    gql`
+      query GetUserPermissionGroupMembers($memberId: String!) {
+        member_permission_group(where: { member_id: { _eq: $memberId } }) {
+          permission_group_id
+          permission_group{
+            name
+            permission_group_members{
+            member_id
+            }
+          }
+        }
+      }`,
+    {
+      variables: {
+        memberId,
+      },
+    }
+  )
+
+  const permissionGroupsMembers =    
+    data?.member_permission_group.flatMap(v =>  v.permission_group.permission_group_members.map(w =>  w.member_id,
+      )
+    ) || []
+
+  console.log('permission-hooks-360', permissionGroupsMembers)
+
+  const { data: permissionGroupsMembersContract } = useQuery<
+    hasura.GetPermissionGroupMembersContract,
+    hasura.GetPermissionGroupMembersContractVariables
+  >(
+    gql`
+      query GetPermissionGroupMembersContract($permissionGroupsMembers: [String!]) {
+        member_contract(where: { author_id: { _in: $permissionGroupsMembers } }) {
+          values
+        }
+      }`,
+    {
+      variables: { permissionGroupsMembers: permissionGroupsMembers },
+    },
+  )
+
+  const permissionGroupsMembersOrderId =
+  permissionGroupsMembersContract?.member_contract.map(v => v.values?.orderId
+  ) || []
+
+  console.log('@permission-hooks@', permissionGroupsMembersOrderId)
+
+  return {
+    loading,
+    permissionGroupsMembersOrderId
+  }
+}
+

--- a/src/pages/SalesPage/SaleSummaryCard.tsx
+++ b/src/pages/SalesPage/SaleSummaryCard.tsx
@@ -7,6 +7,7 @@ import { useIntl } from 'react-intl'
 import AdminCard from '../../components/admin/AdminCard'
 import UnAuthCover from '../../components/common/UnAuthCover'
 import hasura from '../../hasura'
+import { useUserPermissionGroupMembers } from '../../hooks/permission'
 import pageMessages from '../translation'
 
 const SaleSummaryCard: React.VFC = () => {
@@ -16,10 +17,17 @@ const SaleSummaryCard: React.VFC = () => {
 
   return (
     <>
-      {!isAuthenticating && !permissions.GROSS_SALES_ADMIN && !permissions.GROSS_SALES_NORMAL ? <UnAuthCover /> : null}
+      {!isAuthenticating &&
+      !permissions.GROSS_SALES_ADMIN &&
+      !permissions.GROSS_SALES_NORMAL &&
+      !permissions.READ_GROUP_SALES_ALL ? (
+        <UnAuthCover />
+      ) : null}
       <AdminCard>
         {!isAuthenticating && appId && permissions.GROSS_SALES_ADMIN ? (
           <SalesSummaryAdminCard appId={appId} />
+        ) : !isAuthenticating && appId && memberId && permissions.READ_GROUP_SALES_ALL ? (
+          <SalesSummaryGroupCard memberId={memberId} />
         ) : !isAuthenticating && appId && memberId && permissions.GROSS_SALES_NORMAL ? (
           <SalesSummaryNormalCard memberId={memberId} appId={appId} />
         ) : (
@@ -44,6 +52,20 @@ const SalesSummaryAdminCard: React.VFC<{ appId: string }> = ({ appId }) => {
       title={formatMessage(pageMessages['*'].totalSales)}
       suffix={formatMessage(pageMessages['*'].dollar)}
       value={totalOrderAmount >= 0 ? totalOrderAmount : '- -'}
+    />
+  )
+}
+
+const SalesSummaryGroupCard: React.VFC<{ memberId: string }> = ({ memberId }) => {
+  const { formatMessage } = useIntl()
+  const { loading, groupOrderAmount } = useGroupOrderAmount(memberId)
+
+  return (
+    <Statistic
+      loading={loading}
+      title={formatMessage(pageMessages['*'].totalSales)}
+      suffix={formatMessage(pageMessages['*'].dollar)}
+      value={groupOrderAmount >= 0 ? groupOrderAmount : '- -'}
     />
   )
 }
@@ -78,6 +100,22 @@ const useTotalOrderAmount = (appId: string) => {
     error,
   }
 }
+const useGroupOrderAmount = (memberId: string) => {
+  const { permissionGroupsMembersOrderId } = useUserPermissionGroupMembers(memberId)
+  const { loading, data, error } = useQuery<hasura.GetGroupOrderAmount, hasura.GetGroupOrderAmountVariables>(
+    GetGroupOrderAmount,
+    { variables: { id: permissionGroupsMembersOrderId } },
+  )
+  const groupOrderAmount: number =
+    (data?.order_product_aggregate.aggregate?.sum?.price || 0) -
+    (data?.order_discount_aggregate.aggregate?.sum?.price || 0)
+
+  return {
+    loading,
+    groupOrderAmount,
+    error,
+  }
+}
 
 const useSelfOrderAmount = (memberId: string, appId: string) => {
   const { loading, data, error } = useQuery<hasura.GetSelfOrderAmount, hasura.GetSelfOrderAmountVariables>(
@@ -107,6 +145,24 @@ const GetTotalOrderAmount = gql`
       }
     }
     order_discount_aggregate(where: { order_log: { status: { _eq: "SUCCESS" }, app_id: { _eq: $appId } } }) {
+      aggregate {
+        sum {
+          price
+        }
+      }
+    }
+  }
+`
+const GetGroupOrderAmount = gql`
+  query GetGroupOrderAmount($id: [String!]) {
+    order_product_aggregate(where: { order_log: { status: { _eq: "SUCCESS" }, id: { _in: $id } } }) {
+      aggregate {
+        sum {
+          price
+        }
+      }
+    }
+    order_discount_aggregate(where: { order_log: { status: { _eq: "SUCCESS" }, id: { _in: $id } } }) {
       aggregate {
         sum {
           price

--- a/src/pages/SalesPage/SalesPage.tsx
+++ b/src/pages/SalesPage/SalesPage.tsx
@@ -14,6 +14,7 @@ import SaleSummaryCard from './SaleSummaryCard'
 const SalesPage: React.FC = () => {
   const { formatMessage } = useIntl()
   const { permissions } = useAuth()
+
   return (
     <AdminLayout>
       <AdminPageTitle className="mb-4">


### PR DESCRIPTION
<img width="1392" alt="截圖 2025-04-16 晚上8 50 12" src="https://github.com/user-attachments/assets/c73e657e-b1e4-4c5c-9e1c-a3bb4890c3e9" />

增加“讀取組內資料”，當被勾選時，只能看到所在權限組當中，組內成員創建的合約訂單