### PR TITLE
bugfix: prevent order list from crashing when data is missing

### DIFF
--- a/src/hooks/order.ts
+++ b/src/hooks/order.ts
@@ -1,4 +1,4 @@
-import { useMutation, useQuery } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { gql } from '@apollo/client'
 import hasura from '../hasura'
 import { sum, uniq } from 'ramda'
@@ -46,8 +46,6 @@ export const useOrderLogPreviewCollection = (
   }
 
   const { permissionGroupsMembersOrderId } = useUserPermissionGroupMembers(memberId)
-
-  console.log('!!!!order 50!!!', permissionGroupsMembersOrderId)
 
   let condition: hasura.GetOrderLogPreviewCollectionVariables['condition']
   switch (authStatus) {
@@ -98,9 +96,6 @@ export const useOrderLogPreviewCollection = (
         },
       }
   }
-
-  console.log('!!!!order 102!!!', permissionGroupsMembersOrderId)
-  console.log('!!!!order 108!!!', authStatus)
 
   const {
     loading: loadingOrderLogPreviewCollection,

--- a/src/hooks/permission.ts
+++ b/src/hooks/permission.ts
@@ -353,15 +353,13 @@ export const useUserPermissionGroupMembers = (memberId: string) => {
       )
     ) || []
 
-  console.log('permission-hooks-360', permissionGroupsMembers)
-
   const { data: permissionGroupsMembersContract } = useQuery<
     hasura.GetPermissionGroupMembersContract,
     hasura.GetPermissionGroupMembersContractVariables
   >(
     gql`
       query GetPermissionGroupMembersContract($permissionGroupsMembers: [String!]) {
-        member_contract(where: { author_id: { _in: $permissionGroupsMembers } }) {
+        member_contract(where: {author_id: {_in: $permissionGroupsMembers}, agreed_at: {_is_null: false}}) {
           values
         }
       }`,
@@ -372,9 +370,7 @@ export const useUserPermissionGroupMembers = (memberId: string) => {
 
   const permissionGroupsMembersOrderId =
   permissionGroupsMembersContract?.member_contract.map(v => v.values?.orderId
-  ) || []
-
-  console.log('@permission-hooks@', permissionGroupsMembersOrderId)
+  ).filter((_:any) => _ ) || []
 
   return {
     loading,


### PR DESCRIPTION
![截圖 2025-04-17 下午1 20 50](https://github.com/user-attachments/assets/8a439323-b8fb-497a-bbcd-71ed856e8558)

修正因為抓到的資料裡有undefined，而導致無法呈現資料的情況

刪除為拔除的conslo.log