### PR TITLE
feat: add sale export permissiom for READ_GROUP_SALES_ALL

### DIFF
--- a/src/pages/SalesPage/SalesPage.tsx
+++ b/src/pages/SalesPage/SalesPage.tsx
@@ -23,8 +23,9 @@ const SalesPage: React.FC = () => {
       </AdminPageTitle>
 
       <div className="d-flex mb-4">
-        {permissions.SALES_RECORDS_ADMIN && (
+        {(permissions.SALES_RECORDS_ADMIN || permissions.READ_GROUP_SALES_ALL) && (
           <OrderExportModal
+            exportPermission={permissions.SALES_RECORDS_ADMIN ? 'Admin' : 'Group'}
             renderTrigger={({ setVisible }) => (
               <Button className="mr-2" type="primary" icon={<DownloadOutlined />} onClick={() => setVisible(true)}>
                 {formatMessage(pageMessages.SalesPage.export)}


### PR DESCRIPTION
<img width="1235" alt="截圖 2025-04-24 上午10 22 15" src="https://github.com/user-attachments/assets/5b98fb8c-3f5d-4d39-a562-42436cd610e7" />

在銷售管理頁面中，為READ_GRUOP_SALSE_ALL開`匯出資料`的權限，並設定匯出之資料為可讀取之資料。