### PR TITLE
feat: support multi-division members in same division call list selector

### DIFF
--- a/src/components/form/translation.ts
+++ b/src/components/form/translation.ts
@@ -377,6 +377,10 @@ const formMessages = {
       id: 'form.PermissionGroup.SALES_LEAD_SAME_DIVISION_SELECTOR',
       defaultMessage: '同組別名單撥打選擇器功能',
     },
+    SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR: {
+      id: 'form.PermissionGroup.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR',
+      defaultMessage: '同權限組名單撥打選擇器功能',
+    },
 
     // merchandise
     MERCHANDISE_ADMIN: { id: 'form.PermissionGroup.MERCHANDISE_ADMIN', defaultMessage: '所有電商管理' },

--- a/src/hooks/sales.ts
+++ b/src/hooks/sales.ts
@@ -12,7 +12,6 @@ import axios from 'axios'
 import { SorterResult } from 'antd/lib/table/interface'
 import { ManagerSelectorStatus } from '../types/sales'
 
-
 type ManagerWithMemberCountData = {
   manager: {
     email: string
@@ -64,12 +63,12 @@ export const useManagers = (status?: ManagerSelectorStatus) => {
     hasura.GetCurrentMemberPermissionGroupsVariables
   >(
     gql`
-    query GetCurrentMemberPermissionGroups($memberId: String!) {
-      member_permission_group(where: { member_id: { _eq: $memberId } }) {
-        permission_group_id
+      query GetCurrentMemberPermissionGroups($memberId: String!) {
+        member_permission_group(where: { member_id: { _eq: $memberId } }) {
+          permission_group_id
+        }
       }
-    }
-  `,
+    `,
     {
       variables: { memberId: currentMemberId || '' },
       skip: !currentMemberId,
@@ -81,15 +80,16 @@ export const useManagers = (status?: ManagerSelectorStatus) => {
     hasura.GetSamePermissionGroupMembersVariables
   >(
     gql`
-    query GetSamePermissionGroupMembers($permissionGroupIds: [uuid!]!) {
-      member_permission_group(where: { permission_group_id: { _in: $permissionGroupIds } }) {
-        member_id
+      query GetSamePermissionGroupMembers($permissionGroupIds: [uuid!]!) {
+        member_permission_group(where: { permission_group_id: { _in: $permissionGroupIds } }) {
+          member_id
+        }
       }
-    }
-  `,
+    `,
     {
       variables: {
-        permissionGroupIds: currentMemberPermissionGroupsData?.member_permission_group.map(g => g.permission_group_id) || []
+        permissionGroupIds:
+          currentMemberPermissionGroupsData?.member_permission_group.map(g => g.permission_group_id) || [],
       },
       skip: !currentMemberPermissionGroupsData?.member_permission_group.length,
     },
@@ -135,6 +135,46 @@ export const useManagers = (status?: ManagerSelectorStatus) => {
     },
   )
 
+  const isManagerInFilteredGroup = useCallback(
+    (member: any) => {
+      const memberId = member?.id
+      if (!memberId) return false
+
+      switch (status) {
+        case 'onlySameDivision':
+          return sameDivisionMembersData?.member_property?.some(prop => prop.member_id === memberId)
+
+        case 'onlySamePermissionGroup':
+          return samePermissionGroupMembersData?.member_permission_group?.some(group => group.member_id === memberId)
+
+        case 'bothPermissionGroupAndDivision':
+          return (
+            sameDivisionMembersData?.member_property?.some(prop => prop.member_id === memberId) ||
+            samePermissionGroupMembersData?.member_permission_group?.some(group => group.member_id === memberId)
+          )
+
+        default:
+          return true
+      }
+    },
+    [status, sameDivisionMembersData?.member_property, samePermissionGroupMembersData?.member_permission_group],
+  )
+
+  const managers: Manager[] = useMemo(() => {
+    return (
+      data?.member_permission
+        .filter(v => isManagerInFilteredGroup(v.member))
+        .map(v => ({
+          id: v.member?.id || '',
+          name: v.member?.name || '',
+          username: v.member?.username || '',
+          avatarUrl: v.member?.picture_url || null,
+          email: v.member?.email || '',
+          telephone: managerTelephoneExtData?.member_property.find(d => d.member_id === v.member?.id)?.value || '',
+        })) || []
+    )
+  }, [data?.member_permission, isManagerInFilteredGroup, managerTelephoneExtData?.member_property])
+
   if (error) {
     return {
       loading: false,
@@ -144,66 +184,13 @@ export const useManagers = (status?: ManagerSelectorStatus) => {
     }
   }
 
-  const isManagerInFilteredGroup = useCallback((member: any) => {
-    const memberId = member?.id;
-    if (!memberId) return false;
-
-    switch (status) {
-      case 'onlySameDivision':
-        return sameDivisionMembersData?.member_property?.some(
-          prop => prop.member_id === memberId
-        );
-
-      case 'onlySamePermissionGroup':
-        return samePermissionGroupMembersData?.member_permission_group?.some(
-          group => group.member_id === memberId
-        );
-
-      case 'bothPermissionGroupAndDivision':
-        return sameDivisionMembersData?.member_property?.some(
-          prop => prop.member_id === memberId
-        ) || samePermissionGroupMembersData?.member_permission_group?.some(
-          group => group.member_id === memberId
-        );
-
-      default:
-        return true;
-    }
-  }, [
-    status,
-    sameDivisionMembersData?.member_property,
-    samePermissionGroupMembersData?.member_permission_group
-  ]);
-
-  const managers: Manager[] = useMemo(
-    () => {
-      return data?.member_permission
-        .filter(v => isManagerInFilteredGroup(v.member))
-        .map(v => ({
-          id: v.member?.id || '',
-          name: v.member?.name || '',
-          username: v.member?.username || '',
-          avatarUrl: v.member?.picture_url || null,
-          email: v.member?.email || '',
-          telephone: managerTelephoneExtData?.member_property.find(d => d.member_id === v.member?.id)?.value || '',
-        })) || [];
-    },
-    [
-      data?.member_permission,
-      managerTelephoneExtData?.member_property,
-      sameDivisionMembersData?.member_property,
-      samePermissionGroupMembersData?.member_permission_group,
-      status,
-    ],
-  );
-
   const loadingStates = [
     loadingCurrentMemberDivision,
     loadingManagerCollection,
     loadingSamDivisionMembers,
     loadingCurrentMemberPermissionGroups,
     loadingSamePermissionGroupMembers,
-  ];
+  ]
 
   return {
     loading: loadingStates.some(Boolean),
@@ -268,26 +255,26 @@ export const useSales = (salesId: string) => {
 
   const sales: SalesProps | null = data?.member_by_pk
     ? {
-      id: data.member_by_pk.id,
-      pictureUrl: data.member_by_pk.picture_url || null,
-      name: data.member_by_pk.name,
-      email: data.member_by_pk.email,
-      telephone: data.member_by_pk.member_properties[0]?.value || '',
-      metadata: data.member_by_pk.metadata,
-      baseOdds: parseFloat(data.member_by_pk.metadata?.assignment?.odds || '0'),
-      lastAttend: data.member_by_pk.attends[0]
-        ? {
-          startedAt: new Date(data.member_by_pk.attends[0].started_at),
-          endedAt: new Date(data.member_by_pk.attends[0].ended_at),
-        }
-        : null,
-      sharingOfMonth: sum(
-        data.order_executor_sharing.map(sharing => Math.floor(sharing.total_price * sharing.ratio)),
-      ),
-      sharingOrdersOfMonth: data.order_executor_sharing.length,
-      totalDuration: data.member_note_aggregate.aggregate?.sum?.duration || 0,
-      totalNotes: data.member_note_aggregate.aggregate?.count || 0,
-    }
+        id: data.member_by_pk.id,
+        pictureUrl: data.member_by_pk.picture_url || null,
+        name: data.member_by_pk.name,
+        email: data.member_by_pk.email,
+        telephone: data.member_by_pk.member_properties[0]?.value || '',
+        metadata: data.member_by_pk.metadata,
+        baseOdds: parseFloat(data.member_by_pk.metadata?.assignment?.odds || '0'),
+        lastAttend: data.member_by_pk.attends[0]
+          ? {
+              startedAt: new Date(data.member_by_pk.attends[0].started_at),
+              endedAt: new Date(data.member_by_pk.attends[0].ended_at),
+            }
+          : null,
+        sharingOfMonth: sum(
+          data.order_executor_sharing.map(sharing => Math.floor(sharing.total_price * sharing.ratio)),
+        ),
+        sharingOrdersOfMonth: data.order_executor_sharing.length,
+        totalDuration: data.member_note_aggregate.aggregate?.sum?.duration || 0,
+        totalNotes: data.member_note_aggregate.aggregate?.count || 0,
+      }
     : null
 
   return {
@@ -343,7 +330,7 @@ export const useGetManagerWithMemberCount = (managerId: string, appId: string) =
       managerWithMemberCountData: { manager: null, memberCount: 0 },
       errorMembers: null,
       loadingMembers: false,
-      refetchMembers: () => { },
+      refetchMembers: () => {},
     }
   }
 
@@ -431,13 +418,13 @@ export const useManagerLeads = (
               sorter: sorter
                 ? Array.isArray(sorter)
                   ? sorter.map(sorter => ({
-                    columnKey: sorter?.columnKey,
-                    order: sorter?.order === 'ascend' ? 'ASC' : 'DESC',
-                  }))
+                      columnKey: sorter?.columnKey,
+                      order: sorter?.order === 'ascend' ? 'ASC' : 'DESC',
+                    }))
                   : {
-                    columnKey: sorter?.columnKey,
-                    order: sorter?.order === 'ascend' ? 'ASC' : 'DESC',
-                  }
+                      columnKey: sorter?.columnKey,
+                      order: sorter?.order === 'ascend' ? 'ASC' : 'DESC',
+                    }
                 : { columnKey: 'member.assignedAt', order: 'DESC' },
               condition,
             },

--- a/src/pages/SalesLeadPage.tsx
+++ b/src/pages/SalesLeadPage.tsx
@@ -29,33 +29,29 @@ export const StyledLine = styled.div`
   margin: 2px 0;
 `
 
-const SalesLeadManagerSelectorStatus = (): ManagerSelectorStatus => {
+const getSalesLeadManagerSelectorStatus = (): ManagerSelectorStatus => {
   const { permissions } = useAuth()
 
-  const hasPermissionGroupSelector = Boolean(permissions.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR) === true
-  const hasDivisionSelector = Boolean(permissions.SALES_LEAD_SAME_DIVISION_SELECTOR) === true
-  const isAdmin = Boolean(permissions.SALES_LEAD_SELECTOR_ADMIN) === true
+  const hasPermissionGroupSelector = !!permissions.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR
+  const hasDivisionSelector = !!permissions.SALES_LEAD_SAME_DIVISION_SELECTOR
+  const isAdmin = !!permissions.SALES_LEAD_SELECTOR_ADMIN
 
   if (isAdmin) {
     return 'default'
   }
 
-  if (hasPermissionGroupSelector && hasDivisionSelector) {
-    return 'bothPermissionGroupAndDivision'
-  } else if (hasPermissionGroupSelector) {
-    return 'onlySamePermissionGroup'
-  } else if (hasDivisionSelector) {
-    return 'onlySameDivision'
-  } else {
-    return 'default'
-  }
+  if (isAdmin) return 'default'
+  if (hasPermissionGroupSelector && hasDivisionSelector) return 'bothPermissionGroupAndDivision'
+  if (hasPermissionGroupSelector) return 'onlySamePermissionGroup'
+  if (hasDivisionSelector) return 'onlySameDivision'
+  return 'default'
 }
 
 const SalesLeadPage: React.VFC = () => {
   const { formatMessage } = useIntl()
   const { enabledModules } = useApp()
   const { currentMemberId, currentMember, permissions } = useAuth()
-  const { managers } = useManagers(SalesLeadManagerSelectorStatus())
+  const { managers } = useManagers(getSalesLeadManagerSelectorStatus())
   const [activeKey, setActiveKey] = useState('FOLLOWED')
   const [managerId, setManagerId] = useState<string | null>(currentMemberId)
   useMemberContractNotification()
@@ -65,6 +61,11 @@ const SalesLeadPage: React.VFC = () => {
     managers.find(manager => manager.id === managerId) || (permissions.SALES_LEAD_ADMIN ? managers?.[0] : null)
 
   const currentMemberIsManager = managers.some(manager => manager.id === currentMemberId)
+
+  const canSelectManager =
+    permissions.SALES_LEAD_SELECTOR_ADMIN ||
+    permissions.SALES_LEAD_SAME_DIVISION_SELECTOR ||
+    permissions.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR
 
   if (!enabledModules.sales || (!permissions.SALES_LEAD_ADMIN && !permissions.SALES_LEAD_NORMAL && !manager)) {
     return <ForbiddenPage />
@@ -77,10 +78,7 @@ const SalesLeadPage: React.VFC = () => {
           <Icon className="mr-3" component={() => <PhoneOutlined />} />
           <span>{formatMessage(salesMessages.salesLead)}</span>
         </AdminPageTitle>
-        {(permissions.SALES_LEAD_SELECTOR_ADMIN ||
-          permissions.SALES_LEAD_SAME_DIVISION_SELECTOR ||
-          permissions.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR) &&
-        manager ? (
+        {canSelectManager && manager ? (
           <StyledManagerBlock className="d-flex flex-row align-items-center">
             <span className="flex-shrink-0">{formatMessage(pageMessages.SalesLeadPage.agent)}：</span>
             <MemberSelector

--- a/src/pages/SalesLeadPage.tsx
+++ b/src/pages/SalesLeadPage.tsx
@@ -29,7 +29,7 @@ export const StyledLine = styled.div`
   margin: 2px 0;
 `
 
-const getSalesLeadManagerSelectorStatus = (): ManagerSelectorStatus => {
+const useSalesLeadManagerSelectorStatus = (): ManagerSelectorStatus => {
   const { permissions } = useAuth()
 
   const hasPermissionGroupSelector = !!permissions.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR
@@ -51,7 +51,7 @@ const SalesLeadPage: React.VFC = () => {
   const { formatMessage } = useIntl()
   const { enabledModules } = useApp()
   const { currentMemberId, currentMember, permissions } = useAuth()
-  const { managers } = useManagers(getSalesLeadManagerSelectorStatus())
+  const { managers } = useManagers(useSalesLeadManagerSelectorStatus())
   const [activeKey, setActiveKey] = useState('FOLLOWED')
   const [managerId, setManagerId] = useState<string | null>(currentMemberId)
   useMemberContractNotification()

--- a/src/pages/SalesLeadPage.tsx
+++ b/src/pages/SalesLeadPage.tsx
@@ -14,6 +14,7 @@ import SalesLeadTabs, { SelectedLeadStatusCategory } from '../components/sale/Sa
 import hasura from '../hasura'
 import { salesMessages } from '../helpers/translation'
 import { useManagers } from '../hooks/sales'
+import { ManagerSelectorStatus } from '../types/sales'
 import ForbiddenPage from './ForbiddenPage'
 import pageMessages from './translation'
 
@@ -28,12 +29,22 @@ export const StyledLine = styled.div`
   margin: 2px 0;
 `
 
-const SalesLeadManagerSelectorStatus = () => {
+const SalesLeadManagerSelectorStatus = (): ManagerSelectorStatus => {
   const { permissions } = useAuth()
-  if (
-    Boolean(permissions.SALES_LEAD_SAME_DIVISION_SELECTOR) === true &&
-    Boolean(permissions.SALES_LEAD_SELECTOR_ADMIN) === false
-  ) {
+
+  const hasPermissionGroupSelector = Boolean(permissions.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR) === true
+  const hasDivisionSelector = Boolean(permissions.SALES_LEAD_SAME_DIVISION_SELECTOR) === true
+  const isAdmin = Boolean(permissions.SALES_LEAD_SELECTOR_ADMIN) === true
+
+  if (isAdmin) {
+    return 'default'
+  }
+
+  if (hasPermissionGroupSelector && hasDivisionSelector) {
+    return 'bothPermissionGroupAndDivision'
+  } else if (hasPermissionGroupSelector) {
+    return 'onlySamePermissionGroup'
+  } else if (hasDivisionSelector) {
     return 'onlySameDivision'
   } else {
     return 'default'
@@ -66,7 +77,10 @@ const SalesLeadPage: React.VFC = () => {
           <Icon className="mr-3" component={() => <PhoneOutlined />} />
           <span>{formatMessage(salesMessages.salesLead)}</span>
         </AdminPageTitle>
-        {(permissions.SALES_LEAD_SELECTOR_ADMIN || permissions.SALES_LEAD_SAME_DIVISION_SELECTOR) && manager ? (
+        {(permissions.SALES_LEAD_SELECTOR_ADMIN ||
+          permissions.SALES_LEAD_SAME_DIVISION_SELECTOR ||
+          permissions.SALES_LEAD_SAME_PERMISSION_GROUP_SELECTOR) &&
+        manager ? (
           <StyledManagerBlock className="d-flex flex-row align-items-center">
             <span className="flex-shrink-0">{formatMessage(pageMessages.SalesLeadPage.agent)}：</span>
             <MemberSelector

--- a/src/types/sales.ts
+++ b/src/types/sales.ts
@@ -85,6 +85,12 @@ export type Manager = {
   telephone: string
 }
 
+export type ManagerSelectorStatus =
+  | 'default'
+  | 'onlySameDivision'
+  | 'onlySamePermissionGroup'
+  | 'bothPermissionGroupAndDivision'
+
 export type LeadStatus =
   | 'IDLED'
   | 'CONTACTED'


### PR DESCRIPTION
目前有經辦同時隸屬於兩個不同服務的組別。

為了讓經辦可以在名單撥打選擇器中跨組別撥打，需要增加「讀取同權限組資料」的功能。

- Trello 卡片：https://trello.com/c/3PoTaswQ