### PR TITLE
feat:show payment due day in order info

### DIFF
--- a/src/components/sale/SaleCollectionExpandRow.tsx
+++ b/src/components/sale/SaleCollectionExpandRow.tsx
@@ -299,6 +299,13 @@ const SaleCollectionExpandRow = ({
                       })}
                     </div>
                   )}
+                  {orderLog.expiredAt && (
+                    <div>
+                      {formatMessage(saleMessages.SaleCollectionExpandRow.paymentDeadline, {
+                        date: dayjs(orderLog.expiredAt).tz(currentTimeZone).format('YYYY-MM-DD HH:mm'),
+                      })}
+                    </div>
+                  )}
                 </>
               ) : (
                 <>


### PR DESCRIPTION
<img width="1130" alt="截圖 2025-05-14 下午4 27 06" src="https://github.com/user-attachments/assets/527638fb-8778-4d21-a228-1380420bbefa" />

在訂單頁面顯示 付款到期 ：日期 時間
