### PR TITLE
refactor: move permission check into hook and update data fetching logic

### DIFF
--- a/src/components/task/MemberTaskAdminBlock.tsx
+++ b/src/components/task/MemberTaskAdminBlock.tsx
@@ -108,18 +108,7 @@ const MemberTaskAdminBlock: React.FC<{
   localStorageMemberTaskDisplay?: string
   localStorageMemberTaskFilter?: {}
   activeMemberTask?: MemberTaskProps | null
-  permissionGroupIds?: string[]
-  permissions?: {
-    TASK_READ_GROUP_ALL: boolean
-  }
-}> = ({
-  memberId,
-  localStorageMemberTaskDisplay,
-  localStorageMemberTaskFilter,
-  activeMemberTask,
-  permissionGroupIds,
-  permissions,
-}) => {
+}> = ({ memberId, localStorageMemberTaskDisplay, localStorageMemberTaskFilter, activeMemberTask }) => {
   const apolloClient = useApolloClient()
   const { formatMessage } = useIntl()
   const { id: appId, enabledModules, settings } = useApp()
@@ -147,8 +136,6 @@ const MemberTaskAdminBlock: React.FC<{
       memberId,
       excludedIds,
       setExcludedIds,
-      permissionGroupIds,
-      permissions,
       ...filter,
       orderBy,
       limit: display === 'table' ? 10 : undefined,

--- a/src/hooks/task.ts
+++ b/src/hooks/task.ts
@@ -4,6 +4,7 @@ import { useEffect, useState } from 'react'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import hasura, { InputMaybe, order_by } from '../hasura'
 import { MeetingGateway, MemberTaskProps } from '../types/member'
+import { useMemberPermissionGroups } from './member'
 
 export const useTask = (queue: string | null, taskId: string | null) => {
   const { authToken } = useAuth()
@@ -52,26 +53,14 @@ export const useMemberTaskCollection = (options?: {
   group?: string
   orderBy: hasura.GET_MEMBER_TASK_COLLECTIONVariables['orderBy']
   permissionGroupId?: string
-  permissionGroupIds?: string[]
-  permissions?: {
-    TASK_READ_GROUP_ALL?: boolean
-  }
 }) => {
   const defaultOrderBy: hasura.member_task_order_by = { created_at: 'desc' as InputMaybe<order_by> }
-
   const { orderBy = defaultOrderBy } = options || {}
-
   const memberPropertyGroupName = '組別'
+  const { currentMemberId, permissions } = useAuth()
+  const { memberPermissionGroups } = useMemberPermissionGroups(currentMemberId || '')
 
-  const condition: hasura.GET_MEMBER_TASK_COLLECTIONVariables['condition'] = {
-    member: options?.permissionGroupId
-      ? {
-          member_permission_groups: { permission_group_id: { _eq: options?.permissionGroupId } },
-        }
-      : undefined,
-    member_id: {
-      _eq: options?.memberId,
-    },
+  const baseCondition = {
     title: options?.title ? { _ilike: `%${options.title}%` } : undefined,
     category: options?.categoryIds ? { id: { _in: options.categoryIds } } : undefined,
     executor:
@@ -138,20 +127,30 @@ export const useMemberTaskCollection = (options?: {
     deleted_at: { _is_null: true },
   }
 
-  const permissionGroup: hasura.GET_MEMBER_TASK_COLLECTIONVariables['condition'] | undefined =
-    options?.permissions?.TASK_READ_GROUP_ALL && options?.permissionGroupIds
+  const condition: hasura.GET_MEMBER_TASK_COLLECTIONVariables['condition'] = 
+    options?.memberId 
       ? {
-          member: {
+          ...baseCondition,
+          member_id: { _eq: options.memberId },
+          deleted_at: { _is_null: true },
+        }
+      : permissions?.TASK_READ_GROUP_ALL && memberPermissionGroups.length > 0
+      ? {
+          ...baseCondition,
+          executor: {
             member_permission_groups: {
-              permission_group_id: { _in: options.permissionGroupIds },
+              permission_group_id: {
+                _in: memberPermissionGroups.map(p => p.permission_group_id),
+              },
             },
           },
           deleted_at: { _is_null: true },
         }
-      : undefined
+      : {
+          ...baseCondition,
+          member_id: {_eq: options?.memberId,},
+      }
 
-  const activeCondition = permissionGroup ?? condition
-  
   const { loading, error, data, refetch, fetchMore } = useQuery<
     hasura.GET_MEMBER_TASK_COLLECTION,
     hasura.GET_MEMBER_TASK_COLLECTIONVariables
@@ -246,7 +245,7 @@ export const useMemberTaskCollection = (options?: {
     `,
     {
       variables: {
-        condition: activeCondition,
+        condition,
         orderBy,
         limit: options?.limit,
         propertyNames: [memberPropertyGroupName],
@@ -256,74 +255,85 @@ export const useMemberTaskCollection = (options?: {
     },
   )
 
+  const memberTasks: MemberTaskProps[] =
+  data?.member_task.map(v => ({
+    id: v.id,
+    title: v.title || '',
+    priority: v.priority as MemberTaskProps['priority'],
+    status: v.status as MemberTaskProps['status'],
+    category: v.category
+      ? {
+          id: v.category.id,
+          name: v.category.name,
+        }
+      : null,
+    dueAt: v.due_at && new Date(v.due_at),
+    createdAt: v.created_at && new Date(v.created_at),
+    hasMeeting: v.has_meeting,
+    meetingGateway: v.meeting_gateway as MeetingGateway,
+    meetingHours: v.meeting_hours,
+    meet: {
+      id: v.meet?.id,
+      startedAt: v.meet?.started_at,
+      endedAt: v.meet?.ended_at,
+      nbfAt: v.meet?.nbf_at,
+      expAt: v.meet?.exp_at,
+      options: v.meet?.options,
+    },
+    description: v.description || '',
+    member: {
+      id: v.member.id,
+      name: v.member.name || v.member.username,
+    },
+    executor: v.executor
+      ? {
+          id: v.executor.id,
+          name: v.executor.name || v.executor.username,
+          avatarUrl: v.executor.picture_url || null,
+        }
+      : null,
+    author: v.author
+      ? {
+          id: v.author.id,
+          name: v.author.name || v.author.username,
+          avatarUrl: v.author.picture_url || null,
+        }
+      : null,
+    isPrivate: v.is_private,
+  })) || []
+
+  const permissionGroupMemberIds =
+    permissions?.TASK_READ_GROUP_ALL && memberPermissionGroups.length > 0
+      ? memberTasks
+        .filter(task => task.executor)
+        .map(task => task.executor!.id)
+      : undefined
+
   const executors: {
     id: string
     name: string
     group?: string
   }[] =
-    data?.executors.map(v => ({
-      id: v.executor?.id || '',
-      name: v.executor?.name || '',
-      group: v.executor?.member_properties.find(mp => mp.property.name === memberPropertyGroupName)?.value,
-    })) || []
+    data?.executors
+      .filter(v => !permissionGroupMemberIds || (v.executor && permissionGroupMemberIds.includes(v.executor.id)))
+      .map(v => ({
+        id: v.executor?.id || '',
+        name: v.executor?.name || '',
+        group: v.executor?.member_properties.find(mp => mp.property.name === memberPropertyGroupName)?.value,
+      })) || []
 
   const authors: {
     id: string
     name: string
     group?: string
   }[] =
-    data?.authors.map(v => ({
-      id: v.author?.id || '',
-      name: v.author?.name || '',
-      group: v.author?.member_properties.find(mp => mp.property.name === memberPropertyGroupName)?.value,
-    })) || []
-
-  const memberTasks: MemberTaskProps[] =
-    data?.member_task.map(v => ({
-      id: v.id,
-      title: v.title || '',
-      priority: v.priority as MemberTaskProps['priority'],
-      status: v.status as MemberTaskProps['status'],
-      category: v.category
-        ? {
-            id: v.category.id,
-            name: v.category.name,
-          }
-        : null,
-      dueAt: v.due_at && new Date(v.due_at),
-      createdAt: v.created_at && new Date(v.created_at),
-      hasMeeting: v.has_meeting,
-      meetingGateway: v.meeting_gateway as MeetingGateway,
-      meetingHours: v.meeting_hours,
-      meet: {
-        id: v.meet?.id,
-        startedAt: v.meet?.started_at,
-        endedAt: v.meet?.ended_at,
-        nbfAt: v.meet?.nbf_at,
-        expAt: v.meet?.exp_at,
-        options: v.meet?.options,
-      },
-      description: v.description || '',
-      member: {
-        id: v.member.id,
-        name: v.member.name || v.member.username,
-      },
-      executor: v.executor
-        ? {
-            id: v.executor.id,
-            name: v.executor.name || v.executor.username,
-            avatarUrl: v.executor.picture_url || null,
-          }
-        : null,
-      author: v.author
-        ? {
-            id: v.author.id,
-            name: v.author.name || v.author.username,
-            avatarUrl: v.author.picture_url || null,
-          }
-        : null,
-      isPrivate: v.is_private,
-    })) || []
+    data?.authors
+      .filter(v => !permissionGroupMemberIds || memberTasks.some(task => task.executor?.id && task.author?.id === v.author?.id && permissionGroupMemberIds.includes(task.executor.id)))
+      .map(v => ({
+        id: v.author?.id || '',
+        name: v.author?.name || '',
+        group: v.author?.member_properties.find(mp => mp.property.name === memberPropertyGroupName)?.value,
+      })) || []
 
   const loadMoreMemberTasks =
     (data?.member_task_aggregate.aggregate?.count || 0) > (options?.limit || 0)

--- a/src/pages/TaskCollectionPage.tsx
+++ b/src/pages/TaskCollectionPage.tsx
@@ -1,5 +1,4 @@
 import { UserOutlined } from '@ant-design/icons'
-import { gql, useQuery } from '@apollo/client'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import React from 'react'
 import { useIntl } from 'react-intl'
@@ -18,29 +17,7 @@ const TaskCollectionPage: React.FC = () => {
   const { memberTask } = useMemberTask(activeMemberTaskId || '')
 
   const { formatMessage } = useIntl()
-  const { permissions, currentMemberId } = useAuth()
-
-  const { data: permissionGroupData } = useQuery<{
-    member_permission_group: { permission_group_id: string }[]
-  }>(
-    gql`
-      query GET_MEMBER_PERMISSION_GROUP($memberId: String!) {
-        member_permission_group(where: { member_id: { _eq: $memberId } }) {
-          permission_group_id
-        }
-      }
-    `,
-    {
-      skip: !permissions?.TASK_READ_GROUP_ALL || !currentMemberId,
-      variables: { memberId: currentMemberId || '' },
-      fetchPolicy: 'network-only',
-    },
-  )
-
-  const permissionGroupIds =
-    permissionGroupData?.member_permission_group?.map(
-      (pg: { permission_group_id: string }) => pg.permission_group_id,
-    ) || []
+  const { permissions } = useAuth()
 
   if (!permissions.TASK_ADMIN && !permissions.TASK_READ_GROUP_ALL) {
     return <ForbiddenPage />
@@ -57,8 +34,6 @@ const TaskCollectionPage: React.FC = () => {
         localStorageMemberTaskDisplay={localStorageMemberTaskDisplay}
         localStorageMemberTaskFilter={localStorageMemberTaskFilter}
         activeMemberTask={memberTask}
-        permissionGroupIds={permissionGroupIds}
-        permissions={{ TASK_READ_GROUP_ALL: !!permissions.TASK_READ_GROUP_ALL }}
       />
     </AdminLayout>
   )


### PR DESCRIPTION
調整原本的設定，將權限判斷放在hook中

。在學員個人的待辦清單，資料以“學員”為判斷標準，顯示該學員的待辦清單（非登入的人）
。在待辦清單總表，若是user有 1. 被勾選待辦清單中的 `讀取組內資料`，2. 權限組有掛，則資料會以`執行者` 為判斷標準，僅顯示值鐔者為同權限組的資料。
。在總表的篩選器中，執行者僅出現同組別的人員。建立者會顯示，在此限制下資料中的建立者。

<img width="1494" alt="截圖 2025-05-16 下午2 48 39" src="https://github.com/user-attachments/assets/8e76e25c-1f95-4cbd-866c-567aa80081f4" />
<img width="1502" alt="截圖 2025-05-16 下午2 48 18" src="https://github.com/user-attachments/assets/2e089709-bd3d-4f93-a24f-6735834ca2fd" />

