### PR TITLE
fix:enable time selection in paymentDueDate field

### DIFF
--- a/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
+++ b/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
@@ -592,7 +592,11 @@ const MemberContractCreationForm: React.FC<
     const [zeroTaxPrice, setZeroTaxPrice] = useState(0)
     const [paymentDueDate, setPaymentDueDate] = useState<Date | null>(null)
     useEffect(() => {
-      if (paymentDueDate === null && fieldValue?.paymentDueDate) {
+      if (
+        paymentDueDate === null &&
+        fieldValue?.paymentDueDate &&
+        !equals(moment(fieldValue.paymentDueDate).toDate(), paymentDueDate)
+      ) {
         const date = moment(fieldValue?.paymentDueDate).toDate()
         setPaymentDueDate(date)
       }

--- a/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
+++ b/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
@@ -1653,10 +1653,7 @@ const MemberContractCreationForm: React.FC<
                 value={moment(paymentDueDate)}
                 onChange={date => {
                   if (date) {
-                    const now = moment()
-                    const withCurrentTime = date.hour(now.hour()).minute(now.minute()).second(now.second())
-
-                    setPaymentDueDate(withCurrentTime.toDate())
+                    setPaymentDueDate(date.toDate())
                   }
                 }}
                 disabledDate={current => {

--- a/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
+++ b/src/pages/NewMemberContractCreationPage/MemberContractCreationForm.tsx
@@ -1653,7 +1653,9 @@ const MemberContractCreationForm: React.FC<
                 value={moment(paymentDueDate)}
                 onChange={date => {
                   if (date) {
-                    setPaymentDueDate(date.toDate())
+                    const selectedDate = date.toDate()
+                    setPaymentDueDate(selectedDate)
+                    form?.setFieldsValue({ paymentDueDate: moment(selectedDate) })
                   }
                 }}
                 disabledDate={current => {


### PR DESCRIPTION
修正在表單中帶入時間時，系統還是會帶入當下時間之情狀。