### PR TITLE
feat:add receiving account dropdown

### DIFF
--- a/src/components/sale/PaymentCard.tsx
+++ b/src/components/sale/PaymentCard.tsx
@@ -149,6 +149,9 @@ const PaymentCard: React.FC<{
       onRefetch?.()
     }
   }
+  const paymentCheck = payments.map(payment => payment.options?.bankAccountInfo)
+  const bankAccountMessage =
+    paymentCheck && paymentCheck.filter(Boolean).length > 0 ? paymentCheck.filter(Boolean)[0] : ''
 
   return (
     <>
@@ -199,6 +202,15 @@ const PaymentCard: React.FC<{
                     message: order.options?.paymentMode || '',
                     isRender: true,
                   },
+                  ...(payment.method === 'bankTransfer'
+                    ? [
+                        {
+                          title: formatMessage(saleMessages.PaymentCard.receivingAccount),
+                          message: bankAccountMessage,
+                          isRender: true,
+                        },
+                      ]
+                    : []),
                 ]
               : [
                   {
@@ -320,6 +332,7 @@ const PaymentCard: React.FC<{
                       onRefetch={onRefetch}
                       canModifyOperations={['paid']}
                       targetPaymentNo={payment.no}
+                      showBankAccountSelect={true}
                     />
                   )}
 

--- a/src/components/sale/translation.ts
+++ b/src/components/sale/translation.ts
@@ -255,6 +255,10 @@ const saleMessages = {
       id: 'sale.PaymentCard.paymentMode',
       defaultMessage: '付款模式',
     },
+    receivingAccount: {
+      id: 'sale.PaymentCard.receivingAccount',
+      defaultMessage: '收款帳號',
+    },
     amount: {
       id: 'sale.PaymentCard.amount',
       defaultMessage: '款項',

--- a/src/helpers/translation.ts
+++ b/src/helpers/translation.ts
@@ -1295,6 +1295,7 @@ export const orderMessages = {
     referrer: { id: 'order.label.referrer', defaultMessage: '推薦人' },
     orderDiscountName: { id: 'order.label.orderDiscountName', defaultMessage: '折扣名稱' },
     paymentLogPaidAt: { id: 'order.label.paymentLogPaidAt', defaultMessage: '付款時間' },
+    bankAccount: { id: 'order.label.bankAccount', defaultMessage: '收款帳號' },
     // invoice
     invoiceName: { id: 'order.label.invoiceName', defaultMessage: '發票姓名' },
     invoiceEmail: { id: 'order.label.invoiceEmail', defaultMessage: '發票信箱' },


### PR DESCRIPTION
<img width="995" alt="截圖 2025-05-29 晚上7 40 07" src="https://github.com/user-attachments/assets/1403b061-2a53-4a78-9da7-0b074a6a2b49" />

<img width="750" alt="截圖 2025-05-29 下午6 51 57" src="https://github.com/user-attachments/assets/4de3b977-f9eb-48d9-ab8a-c1839f41091c" />


新增收款帳號下拉選單，當結帳管道為 `銀行匯款` 時， 在交易紀錄中的 `變更交易紀錄 ` 內有下拉選單可以選取`收款帳號`。
選單內之`收款帳號` 依據登入者的權限組顯示對應的資料