### PR TITLE
Feat/separate personal and group permission

### DIFF
--- a/src/components/report/ReportAdminModal.tsx
+++ b/src/components/report/ReportAdminModal.tsx
@@ -19,6 +19,7 @@ type FieldProps = {
   dashboard: string
   viewPermissions?: string[]
   canViewSelfDataOnly: boolean
+  canViewGroupDataOnly: boolean
 }
 
 const ReportAdminModal: React.FC<
@@ -40,7 +41,7 @@ const ReportAdminModal: React.FC<
   const { formatMessage } = useIntl()
 
   const generateReportOptions = (formValue: FieldProps) => {
-    const { type, formType, dashboard, question, canViewSelfDataOnly } = formValue
+    const { type, formType, dashboard, question, canViewSelfDataOnly, canViewGroupDataOnly } = formValue
     switch (type) {
       case 'metabase':
         return {
@@ -50,6 +51,7 @@ const ReportAdminModal: React.FC<
             params: formType === 'dashboard' ? { appid: appId } : { appId },
           },
           canViewSelfDataOnly,
+          canViewGroupDataOnly,
         }
       default:
         return null
@@ -150,6 +152,7 @@ const ReportAdminModal: React.FC<
           [originFormType]: report?.options?.metabase?.resource?.[originFormType],
           viewPermissions: report?.viewingPermissions?.map(viewingPermission => viewingPermission.id),
           canViewSelfDataOnly: !!report?.options?.canViewSelfDataOnly,
+          canViewGroupDataOnly: !!report?.options?.canViewGroupDataOnly,
         }}
       >
         <Form.Item
@@ -198,6 +201,9 @@ const ReportAdminModal: React.FC<
         </Form.Item>
         <Form.Item name="canViewSelfDataOnly" valuePropName="checked">
           <Checkbox> {formatMessage(reportMessages.ReportAdminModal.canViewSelfDataOnly)}</Checkbox>
+        </Form.Item>
+        <Form.Item name="canViewGroupDataOnly" valuePropName="checked">
+          <Checkbox>{formatMessage(reportMessages.ReportAdminModal.canViewGroupDataOnly)}</Checkbox>
         </Form.Item>
         {enabledModules.permission_group ? (
           <Form.Item label={formatMessage(reportMessages.ReportAdminModal.viewingPermission)} name="viewPermissions">

--- a/src/components/report/ReportAdminModal.tsx
+++ b/src/components/report/ReportAdminModal.tsx
@@ -202,7 +202,7 @@ const ReportAdminModal: React.FC<
         <Form.Item name="canViewSelfDataOnly" valuePropName="checked">
           <Checkbox> {formatMessage(reportMessages.ReportAdminModal.canViewSelfDataOnly)}</Checkbox>
         </Form.Item>
-        <Form.Item name="canViewGroupDataOnly" valuePropName="checked">
+        <Form.Item name="canViewGroupDataOnly" valuePropName="checked" style={{ marginTop: '-24px' }}>
           <Checkbox>{formatMessage(reportMessages.ReportAdminModal.canViewGroupDataOnly)}</Checkbox>
         </Form.Item>
         {enabledModules.permission_group ? (

--- a/src/components/report/translations.ts
+++ b/src/components/report/translations.ts
@@ -12,6 +12,10 @@ export const reportMessages = {
       id: 'reportMessages.ReportAdminModal.canViewSelfDataOnly',
       defaultMessage: 'Only can view Self Data',
     },
+    canViewGroupDataOnly: {
+      id: 'reportMessages.ReportAdminModal.canViewGroupDataOnly',
+      defaultMessage: 'Only can view Group Data',
+    },
     existReport: { id: 'reportMessages.ReportAdminModal.existReport', defaultMessage: '已存在相同報表' },
     embedSingleReport: {
       id: 'reportMessages.ReportAdminModal.embedSingleReport',

--- a/src/pages/ReportPage/ReportPage.tsx
+++ b/src/pages/ReportPage/ReportPage.tsx
@@ -33,14 +33,6 @@ const ReportPage: React.FC = () => {
   const iframeHeightSetting = Number(settings['report.iframe_height']) || 600
   const [iframeHeight, setIframeHeight] = useState(iframeHeightSetting)
   const { reportId } = useParams<{ reportId: string }>()
-  // 👈 加入更多 debug
-  console.log('=== ReportPage Debug ===')
-  console.log('reportId from useParams:', reportId, typeof reportId)
-  console.log('reportId is undefined:', reportId === undefined)
-  console.log('reportId is null:', reportId === null)
-  console.log('reportId stringified:', JSON.stringify(reportId))
-  console.log('========================')
-
   const { report } = useReport(reportId)
   const { loading: loadingMemberPermissionGroups, memberPermissionGroups } = useMemberPermissionGroups(
     currentMemberId || '',
@@ -49,12 +41,6 @@ const ReportPage: React.FC = () => {
   const startedAt = dayjs(Date.now()).add(-1, 'month').format('YYYY-MM-DD')
   const endedAt = dayjs(Date.now()).format('YYYY-MM-DD')
   const signedUrlWithFilter = `${signedUrl}?startedAt=${startedAt}&endedAt=${endedAt}#titled=false`
-
-  console.log('🖼️ signedUrl:', signedUrl) // 👈 加入這行
-  console.log('🖼️ signedUrlWithFilter:', signedUrlWithFilter) // 👈 加入這行
-  console.log('🖼️ iframe height:', iframeHeight) // 👈 加入這行
-  console.log('🖼️ iframe loading state:', isIframeLoading) // 👈 加入這行
-
   const handleIframeLoad = () => setIframeLoading(false)
 
   if (
@@ -69,8 +55,6 @@ const ReportPage: React.FC = () => {
       !permissions.REPORT_ADMIN)
   )
     return <ForbiddenPage />
-
-  console.log('report object:', report)
 
   return (
     <AdminBlock style={{ height: '100vh' }}>
@@ -103,13 +87,7 @@ const ReportPage: React.FC = () => {
         width="100%"
         height={`${iframeHeight}px`}
         allowTransparency
-        onLoad={() => {
-          console.log('🖼️ iframe loaded successfully!') // 👈 加入這行
-          handleIframeLoad()
-        }}
-        onError={e => {
-          console.error('🖼️ iframe load error:', e) // 👈 加入這行
-        }}
+        onLoad={handleIframeLoad}
         style={{ display: isIframeLoading ? 'none' : 'block' }}
       />
     </AdminBlock>
@@ -120,46 +98,15 @@ const useReportSignedUrlById = (reportId: string, authToken: string) => {
   const [signedUrl, setSignedUrl] = useState<any>(null)
   const [error, setError] = useState<any>('')
   const [isLoading, setLoading] = useState<boolean>(false)
-
-  // 👈 加入這些 debug
-  console.log('=== useReportSignedUrlById Debug ===')
-  console.log('Hook called with reportId:', reportId, typeof reportId)
-  console.log('Hook called with authToken exists:', !!authToken)
-
-  console.log('==================================')
-
   useEffect(() => {
-    console.log('=== useEffect triggered ===')
-    console.log('useEffect reportId:', reportId, typeof reportId)
-    console.log('useEffect authToken exists:', !!authToken)
-
-    if (!reportId || reportId === 'null' || reportId === 'undefined') {
-      console.log('❌ Skipping request - invalid reportId:', reportId)
-      return
-    }
-
-    if (!authToken) {
-      console.log('❌ Skipping request - no authToken')
-      return
-    }
-
-    console.log('✅ Making valid request')
     setLoading(true)
     ;(async () => {
       try {
-        const url = `${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/report/${reportId}`
-        console.log('🚀 Sending request to:', url)
-
-        const response = await axios.get(url, {
+        const response = await axios.get(`${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/report/${reportId}`, {
           headers: { authorization: `Bearer ${authToken}` },
         })
-
-        console.log('📥 Full response:', response) // 👈 加入這行
-        console.log('📥 Response data:', response.data) // 👈 加入這行
-        console.log('📥 Response result:', response.data.result) // 👈 加入這行
         setSignedUrl(() => response.data.result)
       } catch (error) {
-        console.error('❌ Request failed:', error)
         setError(error)
       } finally {
         setLoading(false)

--- a/src/pages/ReportPage/ReportPage.tsx
+++ b/src/pages/ReportPage/ReportPage.tsx
@@ -33,6 +33,14 @@ const ReportPage: React.FC = () => {
   const iframeHeightSetting = Number(settings['report.iframe_height']) || 600
   const [iframeHeight, setIframeHeight] = useState(iframeHeightSetting)
   const { reportId } = useParams<{ reportId: string }>()
+  // 👈 加入更多 debug
+  console.log('=== ReportPage Debug ===')
+  console.log('reportId from useParams:', reportId, typeof reportId)
+  console.log('reportId is undefined:', reportId === undefined)
+  console.log('reportId is null:', reportId === null)
+  console.log('reportId stringified:', JSON.stringify(reportId))
+  console.log('========================')
+
   const { report } = useReport(reportId)
   const { loading: loadingMemberPermissionGroups, memberPermissionGroups } = useMemberPermissionGroups(
     currentMemberId || '',
@@ -41,6 +49,12 @@ const ReportPage: React.FC = () => {
   const startedAt = dayjs(Date.now()).add(-1, 'month').format('YYYY-MM-DD')
   const endedAt = dayjs(Date.now()).format('YYYY-MM-DD')
   const signedUrlWithFilter = `${signedUrl}?startedAt=${startedAt}&endedAt=${endedAt}#titled=false`
+
+  console.log('🖼️ signedUrl:', signedUrl) // 👈 加入這行
+  console.log('🖼️ signedUrlWithFilter:', signedUrlWithFilter) // 👈 加入這行
+  console.log('🖼️ iframe height:', iframeHeight) // 👈 加入這行
+  console.log('🖼️ iframe loading state:', isIframeLoading) // 👈 加入這行
+
   const handleIframeLoad = () => setIframeLoading(false)
 
   if (
@@ -55,6 +69,8 @@ const ReportPage: React.FC = () => {
       !permissions.REPORT_ADMIN)
   )
     return <ForbiddenPage />
+
+  console.log('report object:', report)
 
   return (
     <AdminBlock style={{ height: '100vh' }}>
@@ -87,7 +103,13 @@ const ReportPage: React.FC = () => {
         width="100%"
         height={`${iframeHeight}px`}
         allowTransparency
-        onLoad={handleIframeLoad}
+        onLoad={() => {
+          console.log('🖼️ iframe loaded successfully!') // 👈 加入這行
+          handleIframeLoad()
+        }}
+        onError={e => {
+          console.error('🖼️ iframe load error:', e) // 👈 加入這行
+        }}
         style={{ display: isIframeLoading ? 'none' : 'block' }}
       />
     </AdminBlock>
@@ -98,15 +120,46 @@ const useReportSignedUrlById = (reportId: string, authToken: string) => {
   const [signedUrl, setSignedUrl] = useState<any>(null)
   const [error, setError] = useState<any>('')
   const [isLoading, setLoading] = useState<boolean>(false)
+
+  // 👈 加入這些 debug
+  console.log('=== useReportSignedUrlById Debug ===')
+  console.log('Hook called with reportId:', reportId, typeof reportId)
+  console.log('Hook called with authToken exists:', !!authToken)
+
+  console.log('==================================')
+
   useEffect(() => {
+    console.log('=== useEffect triggered ===')
+    console.log('useEffect reportId:', reportId, typeof reportId)
+    console.log('useEffect authToken exists:', !!authToken)
+
+    if (!reportId || reportId === 'null' || reportId === 'undefined') {
+      console.log('❌ Skipping request - invalid reportId:', reportId)
+      return
+    }
+
+    if (!authToken) {
+      console.log('❌ Skipping request - no authToken')
+      return
+    }
+
+    console.log('✅ Making valid request')
     setLoading(true)
     ;(async () => {
       try {
-        const response = await axios.get(`${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/report/${reportId}`, {
+        const url = `${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/report/${reportId}`
+        console.log('🚀 Sending request to:', url)
+
+        const response = await axios.get(url, {
           headers: { authorization: `Bearer ${authToken}` },
         })
+
+        console.log('📥 Full response:', response) // 👈 加入這行
+        console.log('📥 Response data:', response.data) // 👈 加入這行
+        console.log('📥 Response result:', response.data.result) // 👈 加入這行
         setSignedUrl(() => response.data.result)
       } catch (error) {
+        console.error('❌ Request failed:', error)
         setError(error)
       } finally {
         setLoading(false)

--- a/src/translations/locales/de-de.json
+++ b/src/translations/locales/de-de.json
@@ -3111,6 +3111,7 @@
   "questionLibrary.ui.sortQuestions": "排序題目",
   "questionLibrary.ui.useZhuYinFont": "使用注音字形",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "Only can view Self Data",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "Nur Gruppendaten anzeigen",
   "reportMessages.ReportAdminModal.cancel": "取消",
   "reportMessages.ReportAdminModal.confirm": "確定",
   "reportMessages.ReportAdminModal.embedDashboard": "嵌入儀表板",

--- a/src/translations/locales/en-us.json
+++ b/src/translations/locales/en-us.json
@@ -3113,6 +3113,7 @@
   "questionLibrary.ui.sortQuestions": "Sort Questions",
   "questionLibrary.ui.useZhuYinFont": "Use Zhuyin Font",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "Only can view Self Data",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "Only can view Group Data",
   "reportMessages.ReportAdminModal.cancel": "cancel",
   "reportMessages.ReportAdminModal.confirm": "confirm",
   "reportMessages.ReportAdminModal.embedDashboard": "Embed Dashboard",

--- a/src/translations/locales/id.json
+++ b/src/translations/locales/id.json
@@ -3113,6 +3113,7 @@
   "questionLibrary.ui.sortQuestions": "Urutkan pertanyaan",
   "questionLibrary.ui.useZhuYinFont": "Gunakan font Zhuyin",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "Hanya dapat melihat data pribadi",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "Hanya bisa melihat data dalam grup",
   "reportMessages.ReportAdminModal.cancel": "Batal",
   "reportMessages.ReportAdminModal.confirm": "Konfirmasi",
   "reportMessages.ReportAdminModal.embedDashboard": "Sisipkan dasbor",

--- a/src/translations/locales/ja.json
+++ b/src/translations/locales/ja.json
@@ -3113,6 +3113,7 @@
   "questionLibrary.ui.sortQuestions": "問題を並び替え",
   "questionLibrary.ui.useZhuYinFont": "注音フォントを使用",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "個人データのみ閲覧可能",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "グループ内のデータのみ表示可能",
   "reportMessages.ReportAdminModal.cancel": "キャンセル",
   "reportMessages.ReportAdminModal.confirm": "確認",
   "reportMessages.ReportAdminModal.embedDashboard": "ダッシュボードを埋め込む",

--- a/src/translations/locales/ko.json
+++ b/src/translations/locales/ko.json
@@ -3113,6 +3113,7 @@
   "questionLibrary.ui.sortQuestions": "문항 정렬",
   "questionLibrary.ui.useZhuYinFont": "주음 글꼴 사용",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "개인 데이터만 조회 가능",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "그룹 내 데이터만 보기 가능",
   "reportMessages.ReportAdminModal.cancel": "취소",
   "reportMessages.ReportAdminModal.confirm": "확인",
   "reportMessages.ReportAdminModal.embedDashboard": "대시보드 삽입",

--- a/src/translations/locales/vi.json
+++ b/src/translations/locales/vi.json
@@ -3113,6 +3113,7 @@
   "questionLibrary.ui.sortQuestions": "Sắp xếp câu hỏi",
   "questionLibrary.ui.useZhuYinFont": "Sử dụng Phông chữ Zhuyin",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "Chỉ có thể xem dữ liệu cá nhân",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "Chỉ xem được dữ liệu trong nhóm",
   "reportMessages.ReportAdminModal.cancel": "Hủy",
   "reportMessages.ReportAdminModal.confirm": "Xác nhận",
   "reportMessages.ReportAdminModal.embedDashboard": "Nhúng bảng điều khiển",

--- a/src/translations/locales/zh-cn.json
+++ b/src/translations/locales/zh-cn.json
@@ -3113,6 +3113,7 @@
   "questionLibrary.ui.sortQuestions": "排序题目",
   "questionLibrary.ui.useZhuYinFont": "使用注音字体",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "只能查看个人数据",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "只能查看组内数据",
   "reportMessages.ReportAdminModal.cancel": "取消",
   "reportMessages.ReportAdminModal.confirm": "确定",
   "reportMessages.ReportAdminModal.embedDashboard": "嵌入仪表板",

--- a/src/translations/locales/zh-tw.json
+++ b/src/translations/locales/zh-tw.json
@@ -3113,6 +3113,7 @@
   "questionLibrary.ui.sortQuestions": "排序題目",
   "questionLibrary.ui.useZhuYinFont": "使用注音字形",
   "reportMessages.ReportAdminModal.canViewSelfDataOnly": "只能看個人的數據",
+  "reportMessages.ReportAdminModal.canViewGroupDataOnly": "只能看組內的數據",
   "reportMessages.ReportAdminModal.cancel": "取消",
   "reportMessages.ReportAdminModal.confirm": "確定",
   "reportMessages.ReportAdminModal.embedDashboard": "嵌入儀表板",

--- a/src/types/report.ts
+++ b/src/types/report.ts
@@ -4,6 +4,7 @@ export type ReportProps = {
   type: string
   options: {
     canViewSelfDataOnly: boolean
+    canViewGroupDataOnly: boolean
     metabase: {
       params: {
         appId: string


### PR DESCRIPTION
新增權限邏輯：分離個人權限與組內權限

- 調整原本「只能看個人」的邏輯
- 新增「只能看組內數據」選項，支援同權限組之間的資料共享
- Trello 卡片：https://trello.com/c/0mOqEOcc
