### PR TITLE
fix: correct payment channel display logic

### DIFF
--- a/src/components/sale/PaymentCard.tsx
+++ b/src/components/sale/PaymentCard.tsx
@@ -185,7 +185,9 @@ const PaymentCard: React.FC<{
 
                   {
                     title: formatMessage(saleMessages.PaymentCard.checkoutMethod),
-                    message: paymentMethodFormatter(checkoutMethod),
+                    message: payment.gateway.includes('spgateway')
+                      ? '藍新'
+                      : paymentMethodFormatter(payment.method || payment.gateway),
                     isRender: true,
                   },
                   {


### PR DESCRIPTION
- 修正原本藍新顯示不正確的結帳管道資訊，讓用戶在前台可以正確看到所有付款選項
- Trello 卡排：