### PR TITLE
Fix/fix newebpay option in modal and invoice payment type

### DIFF
--- a/src/components/sale/OrderDetailDrawer.tsx
+++ b/src/components/sale/OrderDetailDrawer.tsx
@@ -544,7 +544,9 @@ const useOrderDetail = (orderLogId: string | null) => {
     })) || []
 
   const paymentMethod: string = !loadingOrderDetail
-    ? paymentMethodFormatter(paymentLogs[0]?.method) || orderLog.options?.paymentMethod || ''
+    ? paymentLogs[0]?.gateway?.includes('spgateway')
+      ? '藍新'
+      : paymentMethodFormatter(paymentLogs[0]?.method) || orderLog.options?.paymentMethod || ''
     : ''
 
   return {

--- a/src/components/sale/PaymentCard.tsx
+++ b/src/components/sale/PaymentCard.tsx
@@ -341,7 +341,7 @@ const PaymentCard: React.FC<{
                     style={{ display: 'flex', alignItems: 'center', gap: 4 }}
                     onClick={() => {
                       setIsOpenChangePaymentMethodModal(true)
-                      setPaymentMethod(paymentMethodFormatter(payment.method))
+                      setPaymentMethod(paymentMethodFormatter(payment.method, payment.gateway)) // 傳入 gateway
                     }}
                   >
                     <div>{formatMessage(saleMessages.PaymentCard.changeCheckoutMethod)}</div>

--- a/src/helpers/index.ts
+++ b/src/helpers/index.ts
@@ -619,7 +619,12 @@ export const signShortUrl = async (url: string, authToken: string | null) => {
 export const memberAccountReceivableAvailable = (memberType: string) =>
   ['B', 'G'].some(v => v === memberType?.trim().match(/^[A-Z]+/)?.[0])
 
-export const paymentMethodFormatter = (paymentMethod: string | null) => {
+export const paymentMethodFormatter = (paymentMethod: string | null, gateway?: string) => {
+
+  if (gateway && gateway.includes('spgateway')) {
+    return '藍新'
+  }
+
   if (!paymentMethod) {
     return paymentMethod
   }


### PR DESCRIPTION
修正 modal 中藍新金流選項會變空白的問題，以及切換為藍新後，發票上的付款別不會正確切換的 bug。

- 修正顯示邏輯，確保 modal 中的藍新金流選項能正常顯示
- 當切換成藍新付款時，發票付款方式會跟著正確變更
- Trello 卡片：https://trello.com/c/TkWjoCWx