### PR TITLE
feat:keep phone invalid when manager reassigned

### DIFF
--- a/src/components/member/MemberProfileBasicForm.tsx
+++ b/src/components/member/MemberProfileBasicForm.tsx
@@ -112,16 +112,14 @@ const MemberProfileBasicForm: React.FC<{
             memberId: memberAdmin.id,
             phones: permissions['MEMBER_PHONE_ADMIN']
               ? phones.map((phone: string, index: number) => {
-                  const oldPhone = memberAdmin.phones.find(
-                    memberPhone => memberPhone.phoneNumber === phone && memberPhone.countryCode === countryCodes[index],
-                  )
+                  const originalPhone = memberAdmin.phones.find(memberPhone => memberPhone.phoneNumber === phone)
 
                   return {
                     member_id: memberAdmin.id,
                     phone,
                     country_code: countryCodes[index],
                     international_phone: `+${countryCodes[index]}${phone}`,
-                    is_valid: typeof oldPhone?.isValid === 'boolean' ? oldPhone.isValid : true,
+                    is_valid: originalPhone !== undefined ? originalPhone.isValid : true,
                   }
                 })
               : phones.map((phone: string, index: number) => ({


### PR DESCRIPTION
<img width="1497" alt="截圖 2025-07-04 上午9 49 52" src="https://github.com/user-attachments/assets/450d45b0-5e61-4a53-86a1-d87bf9147b02" />
<img width="1238" alt="截圖 2025-07-04 上午9 49 41" src="https://github.com/user-attachments/assets/ff58f33b-66f0-438e-876a-7aa66ea4c2fc" />

遇到的問題：
在`名單撥打`，將電話標注無效，回到`會員基本資料`新增電話以及加入指派業務時，標記無效的電話會恢復成有效

更新：
已經標記無效的電話，即便在`會員基本資料`新增電話以及加入指派業務時，標記無效的電話保持無效
