### PR TITLE
refactor: replace is zero tax field with tax type in order detail

### DIFF
--- a/src/components/sale/OrderDetailDrawer.tsx
+++ b/src/components/sale/OrderDetailDrawer.tsx
@@ -164,6 +164,7 @@ const OrderDetailDrawer: React.FC<{
                     companyPhone={company?.companyPhone}
                     isAccountReceivable={isAccountReceivable}
                     isMemberZeroTaxProperty={orderLog.invoiceOptions?.isMemberZeroTaxProperty}
+                    invoiceOptions={orderLog.invoiceOptions}
                   />
                 ) : (
                   shownInvoices.map(i => (
@@ -214,6 +215,7 @@ const OrderDetailDrawer: React.FC<{
                       companyPhone={company?.companyPhone}
                       isAccountReceivable={isAccountReceivable}
                       isMemberZeroTaxProperty={orderLog.invoiceOptions?.isMemberZeroTaxProperty}
+                      invoiceOptions={orderLog.invoiceOptions}
                     />
                   ))
                 )}
@@ -338,6 +340,7 @@ const OrderDetailDrawer: React.FC<{
                     invoiceComment={orderLog.invoiceOptions?.invoiceComment}
                     invoiceGatewayId={company?.invoiceGatewayId}
                     isAccountReceivable={isAccountReceivable}
+                    invoiceOptions={orderLog.invoiceOptions}
                   />
                 )}
                 <StyledTitle>{formatMessage(saleMessages.OrderDetailDrawer.paymentInfo)}</StyledTitle>


### PR DESCRIPTION
修正訂單詳情中的「是否零稅」欄位，改為顯示「課稅別」並正確抓取對應的課稅資料。

- Trello 卡片：https://trello.com/c/e5WIbkbr