### PR TITLE
feat:add invoice setting when B2C has uniformnumber

### DIFF
--- a/src/pages/NewMemberContractCreationPage/MemberContractCreationBlock.tsx
+++ b/src/pages/NewMemberContractCreationPage/MemberContractCreationBlock.tsx
@@ -164,43 +164,19 @@ const MemberContractCreationBlock: React.FC<{
     }
 
     if (category === 'B2B') {
-      if (totalPriceWithTax > 0) {
-        const filteredItems = items.filter(v => v.taxType === '1')
+      if (actualIsMemberZeroTax) {
         invoices.push({
-          TaxType: '1',
-          ItemName: filteredItems.map(v => v.name).join('|'),
-          ItemCount: filteredItems.map(v => v.count).join('|'),
-          ItemUnit: filteredItems.map(v => v.unit).join('|'),
-          ItemPrice: filteredItems.map(v => v.price).join('|'),
-          ItemAmt: filteredItems.map(v => v.amt).join('|'),
-          Amt: totalPriceWithoutTax,
-          TaxAmt: tax,
-          TotalAmt: totalPrice - totalPriceWithFreeTax,
-          TaxRate: 5,
-          MerchantOrderNo: new Date().getTime().toString() + '1',
-          BuyerEmail: fieldValue.invoiceEmail || member.email,
-          BuyerName: fieldValue.uniformTitle,
-          BuyerUBN: fieldValue.uniformNumber,
-          Category: category,
-          Comment: fieldValue.invoiceComment,
-          PrintFlag: 'Y',
-        })
-      }
-
-      if (totalPriceWithFreeTax > 0) {
-        const filteredItems = items.filter(v => v.taxType === '3' || v.taxType === '2')
-        invoices.push({
-          TaxType: '3',
-          Amt: totalPriceWithFreeTax,
-          ItemName: filteredItems.map(v => v.name).join('|'),
-          ItemCount: filteredItems.map(v => v.count).join('|'),
-          ItemUnit: filteredItems.map(v => v.unit).join('|'),
-          ItemPrice: filteredItems.map(v => v.price).join('|'),
-          ItemAmt: filteredItems.map(v => v.amt).join('|'),
+          TaxType: '2',
+          Amt: totalPrice,
           TaxAmt: 0,
-          TotalAmt: totalPriceWithFreeTax,
+          TotalAmt: totalPrice,
           TaxRate: 0,
-          MerchantOrderNo: new Date().getTime().toString() + '3',
+          ItemName: items.map(v => v.name).join('|'),
+          ItemCount: items.map(v => v.count).join('|'),
+          ItemUnit: items.map(v => v.unit).join('|'),
+          ItemPrice: items.map(v => v.price).join('|'),
+          ItemAmt: items.map(v => v.amt).join('|'),
+          MerchantOrderNo: new Date().getTime().toString() + '2',
           BuyerEmail: fieldValue.invoiceEmail || member.email,
           BuyerName: fieldValue.uniformTitle,
           BuyerUBN: fieldValue.uniformNumber,
@@ -208,6 +184,52 @@ const MemberContractCreationBlock: React.FC<{
           Comment: fieldValue.invoiceComment,
           PrintFlag: 'Y',
         })
+      } else {
+        if (totalPriceWithTax > 0) {
+          const filteredItems = items.filter(v => v.taxType === '1')
+          invoices.push({
+            TaxType: '1',
+            ItemName: filteredItems.map(v => v.name).join('|'),
+            ItemCount: filteredItems.map(v => v.count).join('|'),
+            ItemUnit: filteredItems.map(v => v.unit).join('|'),
+            ItemPrice: filteredItems.map(v => v.price).join('|'),
+            ItemAmt: filteredItems.map(v => v.amt).join('|'),
+            Amt: totalPriceWithoutTax,
+            TaxAmt: tax,
+            TotalAmt: totalPrice - totalPriceWithFreeTax,
+            TaxRate: 5,
+            MerchantOrderNo: new Date().getTime().toString() + '1',
+            BuyerEmail: fieldValue.invoiceEmail || member.email,
+            BuyerName: fieldValue.uniformTitle,
+            BuyerUBN: fieldValue.uniformNumber,
+            Category: category,
+            Comment: fieldValue.invoiceComment,
+            PrintFlag: 'Y',
+          })
+        }
+
+        if (totalPriceWithFreeTax > 0) {
+          const filteredItems = items.filter(v => v.taxType === '3' || v.taxType === '2')
+          invoices.push({
+            TaxType: '3',
+            Amt: totalPriceWithFreeTax,
+            ItemName: filteredItems.map(v => v.name).join('|'),
+            ItemCount: filteredItems.map(v => v.count).join('|'),
+            ItemUnit: filteredItems.map(v => v.unit).join('|'),
+            ItemPrice: filteredItems.map(v => v.price).join('|'),
+            ItemAmt: filteredItems.map(v => v.amt).join('|'),
+            TaxAmt: 0,
+            TotalAmt: totalPriceWithFreeTax,
+            TaxRate: 0,
+            MerchantOrderNo: new Date().getTime().toString() + '3',
+            BuyerEmail: fieldValue.invoiceEmail || member.email,
+            BuyerName: fieldValue.uniformTitle,
+            BuyerUBN: fieldValue.uniformNumber,
+            Category: category,
+            Comment: fieldValue.invoiceComment,
+            PrintFlag: 'Y',
+          })
+        }
       }
     }
 


### PR DESCRIPTION
<img width="598" height="762" alt="截圖 2025-07-21 下午3 56 27" src="https://github.com/user-attachments/assets/8f18eb77-1e64-4f54-986f-4e6a16fc9b3d" />
<img width="551" height="363" alt="截圖 2025-07-21 下午3 55 52" src="https://github.com/user-attachments/assets/4e0a918f-f0b9-4ff4-8496-ed4d1d178c8a" />
<img width="828" height="701" alt="截圖 2025-07-21 下午4 11 51" src="https://github.com/user-attachments/assets/1c59a47e-a927-48dd-9ee9-923dcd4b6a0e" />

當客戶為B2C，但有帶入統編時，發票開立為 B2B , TaxType : 2