### PR TITLE
fix: 修正排課訂單分類規則，正確區分小組班與學期班

### DIFF
--- a/src/components/schedule/utils/__tests__/orderNameFilter.test.ts
+++ b/src/components/schedule/utils/__tests__/orderNameFilter.test.ts
@@ -1,0 +1,119 @@
+import { classifyOrderProduct } from '../orderNameFilter'
+
+describe('classifyOrderProduct', () => {
+  describe('product 必須是「學費」', () => {
+    it('product 不是學費 → null（排除註冊費 / 教材）', () => {
+      expect(
+        classifyOrderProduct({
+          product: '註冊費',
+          classType: '團體班',
+          productName: '中文_秋季團班_海內',
+        }),
+      ).toBeNull()
+    })
+
+    it('product 為空 → null', () => {
+      expect(
+        classifyOrderProduct({
+          product: '',
+          classType: '個人班',
+          productName: '個人班_中文',
+        }),
+      ).toBeNull()
+    })
+  })
+
+  describe('個人班嚴格依 class_type', () => {
+    it('class_type === 個人班 → personal', () => {
+      expect(
+        classifyOrderProduct({
+          product: '學費',
+          classType: '個人班',
+          productName: '中文_個人班_60堂',
+        }),
+      ).toBe('personal')
+    })
+
+    it('class_type 是團體班、名稱含「個人」 → 不再歸 personal', () => {
+      const result = classifyOrderProduct({
+        product: '學費',
+        classType: '團體班',
+        productName: '中文_個人混搭_60堂',
+      })
+      expect(result).not.toBe('personal')
+    })
+  })
+
+  describe('「小組」覆蓋學期班關鍵字（規則 3 在規則 4 之前）', () => {
+    it('名稱含「小組」 → group，即使有學期班關鍵字', () => {
+      expect(
+        classifyOrderProduct({
+          product: '學費',
+          classType: '團體班',
+          productName: '中文_學期班_小組_60堂',
+        }),
+      ).toBe('group')
+    })
+
+    it('小組春團班（含「團班」但非「春季團班」） → group', () => {
+      expect(
+        classifyOrderProduct({
+          product: '學費',
+          classType: '團體班',
+          productName: '(2026年)中文_標準_海內_內課_小組春團班_60-71堂',
+        }),
+      ).toBe('group')
+    })
+  })
+
+  describe('學期班關鍵字', () => {
+    it.each([
+      ['冬季團班', '中文_冬季團班_海內'],
+      ['春季團班', '中文_春季團班_海內'],
+      ['秋季團班', '中文_秋季團班_海內'],
+      ['夏季團班', '中文_夏季團班_海內'],
+      ['學期班', '中文_學期班_海內'],
+      ['學期團班', '中文_學期團班_海內'],
+    ])('名稱含「%s」 → semester', (_label, productName) => {
+      expect(
+        classifyOrderProduct({
+          product: '學費',
+          classType: '團體班',
+          productName,
+        }),
+      ).toBe('semester')
+    })
+  })
+
+  describe('group 兜底', () => {
+    it('TLI041089668282386 案例：小型 → group', () => {
+      expect(
+        classifyOrderProduct({
+          product: '學費',
+          classType: '團體班',
+          productName: '(2026年)中文_標準_海內_內課_小型_60-71堂',
+        }),
+      ).toBe('group')
+    })
+
+    it('class_type 為空、名稱無關鍵字 → group', () => {
+      expect(
+        classifyOrderProduct({
+          product: '學費',
+          classType: '',
+          productName: '某產品',
+        }),
+      ).toBe('group')
+    })
+
+    it('class_type 是團體班、名稱無學期班關鍵字 → group', () => {
+      expect(
+        classifyOrderProduct({
+          product: '學費',
+          classType: '團體班',
+          productName: '中文_其他命名_60堂',
+        }),
+      ).toBe('group')
+    })
+  })
+})

--- a/src/components/schedule/utils/orderNameFilter.ts
+++ b/src/components/schedule/utils/orderNameFilter.ts
@@ -31,11 +31,16 @@ export type ClassCategory = 'personal' | 'semester' | 'group'
 /**
  * 統一分類訂單產品屬於哪種班別。
  *
- * 規則：
+ * 規則（依序判斷，先匹配者勝出）：
  * 1. product !== '學費' → null（排除註冊費、教材等）
- * 2. class_type === '個人班' 或名稱含「個人」→ personal
- * 3. class_type === '團體班' 或名稱含任一學期班關鍵字 → semester
- * 4. 其餘學費訂單 → group（小組班）
+ * 2. class_type === '個人班' → personal
+ * 3. 名稱含「小組」 → group（覆蓋優先，吃下「小組春團班」等混搭命名）
+ * 4. 名稱含任一學期班關鍵字 → semester
+ * 5. 其餘 → group（兜底）
+ *
+ * 註：小組班與學期班的 class_type 都是「團體班」，所以無法只靠 class_type
+ * 區分，需要靠名稱關鍵字。「小組」前綴比學期班季節關鍵字更具決定性，
+ * 因此規則 3 必須在規則 4 之前。
  */
 export const classifyOrderProduct = (options: {
   product?: string | null
@@ -48,16 +53,17 @@ export const classifyOrderProduct = (options: {
   const classType = normalize(options.classType)
   const productName = normalize(options.productName)
 
-  // 個人班
-  if (classType === '個人班' || includesKeyword(productName, '個人')) {
+  if (classType === '個人班') {
     return 'personal'
   }
 
-  // 學期班
-  if (classType === '團體班' || SEMESTER_KEYWORDS.some(kw => includesKeyword(productName, kw))) {
+  if (includesKeyword(productName, '小組')) {
+    return 'group'
+  }
+
+  if (SEMESTER_KEYWORDS.some(kw => includesKeyword(productName, kw))) {
     return 'semester'
   }
 
-  // 小組班（兜底）
   return 'group'
 }

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,0 +1,5 @@
+// jest-dom adds custom jest matchers for asserting on DOM nodes.
+// allows you to do things like:
+// expect(element).toHaveTextContent(/react/i)
+// learn more: https://github.com/testing-library/jest-dom
+// import '@testing-library/jest-dom';


### PR DESCRIPTION
## Summary

- 小組班與學期班的 `class_type` 都是「團體班」，舊規則 `class_type === '團體班' → semester` 把所有小組班訂單誤判成學期班，導致小組班的「加入訂單」清單抓不到應有的訂單（例：`TLI041089668282386` 名稱 `(2026年)中文_標準_海內_內課_小型_60-71堂` 永遠進不到小組班）。
- 改為依名稱關鍵字區分：名稱含「小組」一律歸 group（覆蓋優先）→ 名稱含 `[冬/春/秋/夏季團班、學期班、學期團班]` → semester → 其餘學費訂單兜底為 group。個人班嚴格依 `class_type`，移除舊的名稱備援。
- 新增 `classifyOrderProduct` 的單元測試（首批測試，含 `setupTests.ts`），覆蓋 5 條規則、`TLI041089668282386` 案例、混搭命名 `小組春團班`、6 個學期班關鍵字。

## Test plan

- [x] `yarn test src/components/schedule/utils/__tests__/orderNameFilter.test.ts` — 15 passed / 0 failed
- [x] `yarn tsc --noEmit` — 我們改動的檔案與 5 個呼叫端 0 新增錯誤
- [ ] 手動驗證 dev 環境：在小組班「加入訂單」清單中能搜到 `TLI041089668282386`（學生 Jess）
- [ ] 手動驗證：學期班仍能抓到帶 `學期班` / `xx季團班` 名稱的訂單
- [ ] 手動驗證：個人班行為不變