### PR TITLE
fix: 學期班排課結束日改為最早訂單建立日 + 180 天

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,3 @@
+[tools]
+node = "16"
+yarn = "1"

--- a/src/components/schedule/ScheduleConditionPanel.tsx
+++ b/src/components/schedule/ScheduleConditionPanel.tsx
@@ -48,6 +48,7 @@ interface ScheduleConditionPanelProps {
   minutesLimitOverride?: number
   endDateLimitMode?: 'latest' | 'earliest'
   disabled?: boolean // Explicitly control disabled state (defaults to selectedOrders.length === 0)
+  maxEndDateOverride?: Moment | null // undefined: use expiryDateByLanguage; Moment: use directly; null: no orders available
 }
 
 const ScheduleConditionPanel: React.FC<ScheduleConditionPanelProps> = ({
@@ -60,6 +61,7 @@ const ScheduleConditionPanel: React.FC<ScheduleConditionPanelProps> = ({
   minutesLimitOverride,
   endDateLimitMode = 'latest',
   disabled,
+  maxEndDateOverride,
 }) => {
   const { formatMessage } = useIntl()
 
@@ -73,6 +75,15 @@ const ScheduleConditionPanel: React.FC<ScheduleConditionPanelProps> = ({
   // Calculate limits based on selected orders and language expiry settings
   const limits = useMemo(() => {
     const defaultMaxDate = moment().add(180, 'day')
+
+    if (maxEndDateOverride !== undefined) {
+      return {
+        maxStartDate: defaultMaxDate,
+        maxEndDate: maxEndDateOverride,
+        maxMinutes: normalizedMinutesLimitOverride ?? 0,
+        earliestOrderDate: moment(),
+      }
+    }
 
     // Calculate max end date from expiryDateByLanguage (used for semester/group classes)
     const calculateMaxEndDateFromLanguage = (): moment.Moment => {
@@ -166,7 +177,14 @@ const ScheduleConditionPanel: React.FC<ScheduleConditionPanelProps> = ({
       maxMinutes: normalizedMinutesLimitOverride ?? totalMinutes,
       earliestOrderDate,
     }
-  }, [selectedOrders, expiryDateByLanguage, minutesLimitMode, normalizedMinutesLimitOverride, endDateLimitMode])
+  }, [
+    selectedOrders,
+    expiryDateByLanguage,
+    minutesLimitMode,
+    normalizedMinutesLimitOverride,
+    endDateLimitMode,
+    maxEndDateOverride,
+  ])
 
   // Mode: endDate or totalLessons
   const [mode, setMode] = React.useState<'endDate' | 'totalLessons'>(() =>
@@ -306,16 +324,19 @@ const ScheduleConditionPanel: React.FC<ScheduleConditionPanelProps> = ({
               value={condition.endDate ? moment(condition.endDate) : null}
               onChange={handleEndDateChange}
               disabledDate={date =>
-                date.isBefore(moment(condition.startDate), 'day') || date.isAfter(limits.maxEndDate, 'day')
+                date.isBefore(moment(condition.startDate), 'day') ||
+                (limits.maxEndDate !== null && date.isAfter(limits.maxEndDate, 'day'))
               }
               disabled={isDisabled}
               style={{ width: '100%' }}
             />
             <HelpText type="secondary">
-              {formatMessage(scheduleMessages.ScheduleCondition.endDateRange, {
-                start: moment().format('YYYY-MM-DD'),
-                end: limits.maxEndDate.format('YYYY-MM-DD'),
-              })}
+              {limits.maxEndDate
+                ? formatMessage(scheduleMessages.ScheduleCondition.endDateRange, {
+                    start: moment().format('YYYY-MM-DD'),
+                    end: limits.maxEndDate.format('YYYY-MM-DD'),
+                  })
+                : formatMessage(scheduleMessages.ScheduleCondition.endDateRequiresOrders)}
             </HelpText>
           </>
         ) : (
@@ -333,16 +354,19 @@ const ScheduleConditionPanel: React.FC<ScheduleConditionPanelProps> = ({
                     value={condition.endDate ? moment(condition.endDate) : null}
                     onChange={handleEndDateChange}
                     disabledDate={date =>
-                      date.isBefore(moment(condition.startDate), 'day') || date.isAfter(limits.maxEndDate, 'day')
+                      date.isBefore(moment(condition.startDate), 'day') ||
+                      (limits.maxEndDate !== null && date.isAfter(limits.maxEndDate, 'day'))
                     }
                     disabled={isDisabled}
                     style={{ width: '100%' }}
                   />
                   <HelpText type="secondary">
-                    {formatMessage(scheduleMessages.ScheduleCondition.endDateRange, {
-                      start: moment().format('YYYY-MM-DD'),
-                      end: limits.maxEndDate.format('YYYY-MM-DD'),
-                    })}
+                    {limits.maxEndDate
+                      ? formatMessage(scheduleMessages.ScheduleCondition.endDateRange, {
+                          start: moment().format('YYYY-MM-DD'),
+                          end: limits.maxEndDate.format('YYYY-MM-DD'),
+                        })
+                      : formatMessage(scheduleMessages.ScheduleCondition.endDateRequiresOrders)}
                   </HelpText>
                 </div>
               )}

--- a/src/components/schedule/StudentListPanel.tsx
+++ b/src/components/schedule/StudentListPanel.tsx
@@ -148,8 +148,7 @@ const StudentListPanel: React.FC<StudentListPanelProps> = ({
         const orderExpiredAt = order.expired_at ? new Date(order.expired_at) : null
         const computedExpiry = expiryDateByOrderId[order.id]
         const hasScheduledEvent = Boolean(hasScheduledEventByOrderId[order.id])
-        const productEndedAt = classProduct.ended_at ? new Date(classProduct.ended_at) : null
-        const expiresAt = hasScheduledEvent ? computedExpiry || productEndedAt : null
+        const expiresAt = hasScheduledEvent ? computedExpiry || null : null
         const campusFromOptions =
           orderOptions?.campus_id || orderOptions?.campusId || productMeta?.campus_id || productMeta?.campusId || null
 
@@ -158,10 +157,6 @@ const StudentListPanel: React.FC<StudentListPanelProps> = ({
         }
 
         if (orderExpiredAt && orderExpiredAt < now) {
-          return null
-        }
-
-        if (expiresAt && new Date(expiresAt) < now) {
           return null
         }
 

--- a/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
+++ b/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
@@ -302,11 +302,10 @@ const ClassGroupScheduleEditorInner: React.FC<ClassGroupScheduleEditorProps> = (
           totalSessions,
           scheduleCondition.startDate,
         )
-        const expiresAt = expiryBySetting || (classProduct.ended_at ? new Date(classProduct.ended_at) : undefined)
+        const expiresAt = expiryBySetting || undefined
 
         if (!isOrderStatusValidForSchedule(orderLog.status)) return null
         if (expiredAt && expiredAt < now) return null
-        if (expiresAt && expiresAt < now) return null
         if (classGroup.campusId && campusFromOptions && campusFromOptions !== classGroup.campusId) {
           return null
         }

--- a/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
+++ b/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
@@ -17,7 +17,7 @@ import {
 import { ColumnsType } from 'antd/lib/table'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
-import moment from 'moment'
+import moment, { Moment } from 'moment'
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { useHistory, useParams } from 'react-router-dom'
@@ -55,6 +55,7 @@ import { AdminPageBlock, AdminPageTitle } from '../../admin'
 import { GeneralEventApi } from '../../event/events.type'
 import AdminLayout from '../../layout/AdminLayout'
 import { classifyOrderProduct, isOrderStatusValidForSchedule } from '../utils/orderNameFilter'
+import { computeSemesterMaxEndDate } from '../utils/semesterDateRange'
 import { buildClassMetadata, getEventKey } from './classFlow/metadata'
 import { ScheduleEditorProvider, useScheduleEditorStore, useScheduleEditorStoreApi } from './ScheduleEditorContext'
 
@@ -234,7 +235,7 @@ const ClassGroupScheduleEditorInner: React.FC<ClassGroupScheduleEditorProps> = (
   const { updateClassGroup } = useUpdateClassGroup()
   const { teachers: allTeachers } = useTeachersFromMembers()
 
-  const { calculateExpiryDate, getMaxExpiryDateForLanguage } = useScheduleExpirySettings(scheduleType)
+  const { calculateExpiryDate } = useScheduleExpirySettings(scheduleType)
 
   const orderIds = classGroup?.orderIds || []
   const { orders: orderLogs } = useOrdersByIds(orderIds)
@@ -622,12 +623,12 @@ const ClassGroupScheduleEditorInner: React.FC<ClassGroupScheduleEditorProps> = (
     return map
   }, [scheduleType, classOrders])
 
-  const expiryDateByLanguage = useMemo<Record<string, Date | null>>(() => {
-    if (scheduleType !== 'semester' || !classGroup?.language) return {}
-    return {
-      [classGroup.language]: getMaxExpiryDateForLanguage(classGroup.language, scheduleCondition.startDate),
-    }
-  }, [scheduleType, classGroup?.language, getMaxExpiryDateForLanguage, scheduleCondition.startDate])
+  const expiryDateByLanguage = useMemo<Record<string, Date | null>>(() => ({}), [])
+
+  const semesterMaxEndDate = useMemo<Moment | null | undefined>(() => {
+    if (scheduleType !== 'semester') return undefined
+    return computeSemesterMaxEndDate(classOrders)
+  }, [scheduleType, classOrders])
 
   const groupBaseAvailableMinutes = useMemo(() => {
     if (scheduleType !== 'group') return 0
@@ -1995,6 +1996,7 @@ const ClassGroupScheduleEditorInner: React.FC<ClassGroupScheduleEditorProps> = (
             expiryDateByLanguage={expiryDateByLanguage}
             minutesLimitOverride={scheduleType === 'group' ? groupRemainingMinutes : undefined}
             disabled={false}
+            maxEndDateOverride={semesterMaxEndDate}
           />
         </ThreeColumnGrid>
 

--- a/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
+++ b/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
@@ -306,7 +306,10 @@ const ClassGroupScheduleEditorInner: React.FC<ClassGroupScheduleEditorProps> = (
                 totalSessions,
                 scheduleCondition.startDate,
               )
-        const expiresAt = expiryBySetting || (classProduct.ended_at ? new Date(classProduct.ended_at) : undefined)
+        const expiresAt =
+          scheduleType === 'semester'
+            ? undefined
+            : expiryBySetting || (classProduct.ended_at ? new Date(classProduct.ended_at) : undefined)
 
         if (!isOrderStatusValidForSchedule(orderLog.status)) return null
         if (expiredAt && expiredAt < now) return null

--- a/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
+++ b/src/components/schedule/editor/ClassGroupScheduleEditor.tsx
@@ -297,12 +297,15 @@ const ClassGroupScheduleEditorInner: React.FC<ClassGroupScheduleEditorProps> = (
         const expiredAt = orderLog.expired_at ? new Date(orderLog.expired_at) : null
         const campusFromOptions =
           orderOptions?.campus_id || orderOptions?.campusId || productMeta?.campus_id || productMeta?.campusId || null
-        const expiryBySetting = calculateExpiryDate(
-          productMeta?.language || classGroup.language,
-          totalSessions,
-          scheduleCondition.startDate,
-        )
-        const expiresAt = expiryBySetting || undefined
+        const expiryBySetting =
+          scheduleType === 'semester'
+            ? null
+            : calculateExpiryDate(
+                productMeta?.language || classGroup.language,
+                totalSessions,
+                scheduleCondition.startDate,
+              )
+        const expiresAt = expiryBySetting || (classProduct.ended_at ? new Date(classProduct.ended_at) : undefined)
 
         if (!isOrderStatusValidForSchedule(orderLog.status)) return null
         if (expiredAt && expiredAt < now) return null

--- a/src/components/schedule/translation.ts
+++ b/src/components/schedule/translation.ts
@@ -90,6 +90,10 @@ const scheduleMessages = {
       id: 'schedule.ScheduleCondition.holidayWarning',
       defaultMessage: 'Holidays may be scheduled into courses, please confirm again',
     },
+    endDateRequiresOrders: {
+      id: 'schedule.ScheduleCondition.endDateRequiresOrders',
+      defaultMessage: '請先新增訂單以計算可選範圍',
+    },
   }),
   TeacherList: defineMessages({
     title: { id: 'schedule.TeacherList.title', defaultMessage: 'Select teacher schedule to display' },

--- a/src/components/schedule/utils/__tests__/semesterDateRange.test.ts
+++ b/src/components/schedule/utils/__tests__/semesterDateRange.test.ts
@@ -1,0 +1,40 @@
+import moment from 'moment'
+import { computeSemesterMaxEndDate } from '../semesterDateRange'
+
+type OrderLike = { createdAt: Date }
+
+describe('computeSemesterMaxEndDate', () => {
+  it('回傳 null 當 orders 為空', () => {
+    expect(computeSemesterMaxEndDate([])).toBeNull()
+  })
+
+  it('1 張訂單 → createdAt + 180 天', () => {
+    const createdAt = new Date('2026-01-10T00:00:00Z')
+    const order: OrderLike = { createdAt }
+    const result = computeSemesterMaxEndDate([order])
+    expect(result).not.toBeNull()
+    expect(result!.isSame(moment(createdAt).add(180, 'day'), 'day')).toBe(true)
+  })
+
+  it('多張訂單 → 取最早 createdAt + 180 天', () => {
+    const orders: OrderLike[] = [
+      { createdAt: new Date('2026-03-01T00:00:00Z') },
+      { createdAt: new Date('2026-01-10T00:00:00Z') },
+      { createdAt: new Date('2026-02-15T00:00:00Z') },
+    ]
+    const result = computeSemesterMaxEndDate(orders)
+    expect(result!.isSame(moment('2026-01-10').add(180, 'day'), 'day')).toBe(true)
+  })
+
+  it('createdAt 相同 → 與任一相同基準等價', () => {
+    const createdAt = new Date('2026-02-01T00:00:00Z')
+    const orders: OrderLike[] = [{ createdAt }, { createdAt }]
+    const result = computeSemesterMaxEndDate(orders)
+    expect(result!.isSame(moment(createdAt).add(180, 'day'), 'day')).toBe(true)
+  })
+
+  it('回傳的是 Moment 物件（非 Date）', () => {
+    const result = computeSemesterMaxEndDate([{ createdAt: new Date() }])
+    expect(moment.isMoment(result)).toBe(true)
+  })
+})

--- a/src/components/schedule/utils/semesterDateRange.ts
+++ b/src/components/schedule/utils/semesterDateRange.ts
@@ -1,0 +1,12 @@
+import moment, { Moment } from 'moment'
+
+type OrderLike = { createdAt: Date }
+
+export const computeSemesterMaxEndDate = (orders: OrderLike[]): Moment | null => {
+  if (orders.length === 0) return null
+  const earliest = orders.reduce(
+    (acc, order) => (moment(order.createdAt).isBefore(acc) ? moment(order.createdAt) : acc),
+    moment(orders[0].createdAt),
+  )
+  return earliest.clone().add(180, 'day')
+}

--- a/src/hooks/scheduleManagement.ts
+++ b/src/hooks/scheduleManagement.ts
@@ -1553,7 +1553,9 @@ export const useScheduleExpirySettings = (scheduleType: ScheduleType = 'personal
   const { data, loading, error } = useQuery<
     hasura.GET_SCHEDULE_VALIDITY_RULES_FOR_SCHEDULE,
     hasura.GET_SCHEDULE_VALIDITY_RULES_FOR_SCHEDULEVariables
-  >(GET_SCHEDULE_VALIDITY_RULES_FOR_SCHEDULE)
+  >(GET_SCHEDULE_VALIDITY_RULES_FOR_SCHEDULE, {
+    skip: scheduleType === 'semester',
+  })
 
   // Map type to DB value
   const dbType = scheduleType === 'personal' ? 'individual' : scheduleType === 'group' ? 'group' : 'individual'


### PR DESCRIPTION
## Summary

- 學期班（semester class）完全脫離 `schedule_validity_rule`（課時到期規則）。該 rule 表僅有 `individual` / `group` 兩種 type，套用在學期班上語意錯誤。
- UI「可選範圍」的 `maxEndDate` 改為「最早訂單 `createdAt` + 180 天」，由新純函式 `computeSemesterMaxEndDate` 產出。
- Per-order `order.expiresAt` 在學期班直接為 `undefined`（不再受 rule 或 `order_product.ended_at` 影響），避免 tli1956 實機資料中 `ended_at ≈ created_at` 造成學期班訂單被誤過濾。
- 小組班、個人班行為完全維持。

## 資料驗證（tli1956 dev env）

- `schedule_validity_rule` 在 tli1956 **沒有 `type = 'semester'`** 的資料——語意錯誤已獲資料驗證。
- 採樣 30 張秋季學期班訂單，`order_product.ended_at` 100% 非未來值（17 筆 = 建立時間、9 筆 null、4 筆舊時間）；若用此作為 `expiresAt`，訂單會被整批誤過濾。已修正。

## 改動檔案

- `src/components/schedule/utils/semesterDateRange.ts`（新）+ 測試（5 cases，全綠）
- `src/components/schedule/ScheduleConditionPanel.tsx`——新 `maxEndDateOverride` prop、null-guard、新 hint 訊息
- `src/components/schedule/editor/ClassGroupScheduleEditor.tsx`——semester 繞過 `calculateExpiryDate`、計算並傳入 `semesterMaxEndDate`
- `src/hooks/scheduleManagement.ts`——`useScheduleExpirySettings` 在 semester 模式 `skip` query
- `src/components/schedule/translation.ts`——新增 `endDateRequiresOrders`

## Test plan

- [ ] 學期班建立模式，未加訂單時 End Date 欄位停用，hint 顯示「請先新增訂單以計算可選範圍」
- [ ] 學期班加 1 張訂單，DatePicker 上限 = 該訂單 `createdAt` + 180 天
- [ ] 學期班加多張訂單，上限 = `min(createdAt) + 180 天`
- [ ] 學期班 Network tab 不再發出 `GET_SCHEDULE_VALIDITY_RULES_FOR_SCHEDULE`
- [ ] 小組班「可選範圍」仍依 `schedule_validity_rule` 計算（迴歸）
- [ ] 個人班完全不受影響（迴歸）

🤖 Generated with [Claude Code](https://claude.com/claude-code)