### PR TITLE
fix(coin): 修正代幣紀錄清單的分頁漏行與發送後畫面不更新

### DIFF
--- a/docs/adr/0001-coin-log-seek-pagination.md
+++ b/docs/adr/0001-coin-log-seek-pagination.md
@@ -96,15 +96,26 @@ seek 只能往下連續取。目前 UI 只有「顯示更多」、沒有頁碼,�
   按鈕正確隱藏。
 - **實際 UI 行為尚未在部署環境驗證**,需上測試站點擊確認。
 
+## 已決定(2026-08-07 討論後補記)
+
+- **不加 `created_at` 索引。** 每筆寫入都要多維護一份索引,寫入成本不划算;
+  且 Hasura 無法表達 row-value 比較 `(created_at, id) < (?, ?)`,只能展開成
+  `_or` + `_and`,Postgres 對這個形狀不保證能從索引中段起跳 —— 即使加了,
+  效能收益也不確定。seek 在本查詢的價值定位為**正確性**,不是效能。
+- **收回代幣後補 refetch「即將發送」tab。** 兩個 tab 的收回按鈕共用
+  `handleRevokeCoin`,原本只 refetch 發送紀錄,在「即將發送」tab 收回後
+  畫面與 cache 會殘留已刪除的列,下一頁游標取到 stale 資料。已併入本次修正。
+
 ## 尚未決定
 
-1. `coin_log` 目前沒有 `created_at` 索引(只有 `pkey(id)` 與 `(member_id, started_at)`),
-   每次查詢仍是整排掃描後排序。seek 的效能優勢要配 `(created_at desc, id desc)` 複合索引
-   才拿得到 —— 但 Hasura 無法表達 row-value 比較 `(created_at, id) < (?, ?)`,
-   只能展開成 `_or` + `_and`,Postgres 對這個形狀不保證會走複合索引。
-   加索引前必須先確認執行計畫。
+1. **排序鍵要不要從 `created_at` 換成 `started_at`(代幣效期)。**
+   產品層的出發點:對使用者而言效期比建立時間重要,且 `created_at` 排序被視為
+   歷史共業。但技術上須三件一起改,不宜順手做:
+   - 全表 83,154 筆中 **12,494 筆(15%)的 `started_at` 為 NULL**(「即日起」),
+     Hasura `desc` 是 NULLS FIRST → 清單頂端會先出現一整塊萬筆級的 NULL 群,
+     且游標條件無法表達 `started_at < NULL`,seek 要拆成 NULL 區/跨區/非 NULL 區三段
+   - 清單第一欄顯示的是建立日期,改排 `started_at` 後該欄會呈現亂序,
+     顯示欄位需一併調整
+   - 現有 `(member_id, started_at)` 索引第一鍵是 `member_id`,全站清單吃不到
 2. `src/pages/PointHistoryAdminPage.tsx:305,381`(點數)有完全相同的 offset 寫法,
-   尚未處理。
-3. `handleRevokeCoin` 刪除後只呼叫 `refetchCoinLogs()`,但「即將發送」tab 的收回按鈕
-   走同一個 function → 在該 tab 收回後,畫面與 cache 不同步。
-   本次未修,待決定是否併入。
+   尚未處理(與本 PR 無關,另案)。

--- a/docs/adr/0001-coin-log-seek-pagination.md
+++ b/docs/adr/0001-coin-log-seek-pagination.md
@@ -1,0 +1,110 @@
+# ADR 0001:代幣紀錄清單改用 seek pagination
+
+- 日期:2026-08-06
+- 狀態:已接受
+- 相關:`src/components/coin/MemberCoinAdminBlock.tsx`
+
+## 背景
+
+客戶 `neganchor` 回報某位會員的代幣紀錄「學員端看得到、管理端看不到」。
+資料本身完整無誤,問題在管理端清單的分頁。查下來有兩個獨立缺陷。
+
+**一、`order_by` 缺唯一鍵。** 批次發送會產生大量 `created_at` 完全相同的資料列
+(同一個 statement 共用 transaction 時間戳,實務上單一微秒數十筆)。
+原本只有 `order_by: { created_at: desc }`,而每一頁都是一次獨立查詢、各自排序一次,
+Postgres 對並列值不保證跨查詢一致 —— 相鄰兩頁對「誰排第 N 名」的認知不一致,
+交界處同時產生重複列與漏行。
+
+正式站唯讀實測(管理端實際的查詢條件,翻 10 頁):修正前 100 列只有 **89 個唯一 id**,
+補上 `{ id: desc }` 後 **100/100**。
+
+> 這不是排序錯亂 —— `created_at` 全程單調遞減,畫面上沒有任何視覺訊號,
+> 唯一症狀是某一列安靜地不見了。這是它長期未被發現的原因。
+
+**二、分頁狀態存在從不重設的 ref。** `storeCreatedTime` / `currentIndex` 只在初次載入時
+寫入、之後永不重設。發送代幣成功後會 `refetch`,但 refetch 只回第一頁:
+`storeCreatedTime` 凍結在發送前的時間戳,而 `loadMore` 的條件是 `created_at <= 它`,
+把剛發出去的資料整批擋在門外;`currentIndex` 只增不減,跳號漏行。
+
+實際後果:一次發送 16 人 → 畫面只出現 10 筆 → 操作者以為有 6 人沒發成功 → 補發。
+這正是本次客訴的成因。
+
+## 決策
+
+**改用 seek pagination,以最後一筆的 `(created_at, id)` 為游標。**
+
+`offset` 問的是「跳過前 N 筆」—— 資料庫只是在數數,不知道上次看到誰。
+翻頁途中前面被刪掉一筆,後面全部往前挪一格,交界那筆就被含進「前 N 筆」一起跳掉。
+這是 offset 的結構性限制,補任何上界條件都無解(上界只擋得住新增,擋不住刪除)。
+
+```ts
+const afterCursor = (cursor: { created_at: any; id: string }) => ({
+  _or: [
+    { created_at: { _lt: cursor.created_at } },
+    { _and: [{ created_at: { _eq: cursor.created_at } }, { id: { _lt: cursor.id } }] },
+  ],
+})
+```
+
+游標是一組值的比較,不是位置 —— **游標那一列本身被刪除也不影響**。
+
+## 取捨
+
+### `order_by` 的 `id` 不可移除
+
+游標條件必須與 `order_by: [{ created_at: desc }, { id: desc }]` 完全一致。
+移除 `id` 會讓排序不唯一,游標就沒有座標可指,而且**不會報錯**,只會靜默漏行。
+
+### `condition` 必須用 `_and` 包住
+
+`condition` 本身已經有一個 `_or`(`started_at is null OR <= now()`)。
+展開後直接加 `_or` 會覆蓋掉它,同樣不會報錯,只會安靜地多查出未生效的代幣。
+
+### aggregate 要跟著游標重算
+
+`fetchMore` 回來的 `aggregate.count` 是「游標之後還有幾筆」,
+必須加上已載入筆數才能還原成總數:
+
+```ts
+count: prev.coin_log.length + (fetchMoreResult.coin_log_aggregate.aggregate?.count || 0)
+```
+
+否則「顯示更多」按鈕的判斷式(`count - 已載入 > 0`)會用到初次查詢的陳舊總數 ——
+翻頁途中資料被刪除時,已載入筆數永遠追不上,按鈕不會消失。
+
+### 無法跳頁
+
+seek 只能往下連續取。目前 UI 只有「顯示更多」、沒有頁碼,不受影響;
+日後若要加頁碼則做不到。
+
+## 被推翻的替代方案
+
+### 只補 `{ id: desc }`,保留 offset
+
+能解決排序不唯一,實測從 89/100 變成 100/100。但對「翻頁途中刪除」無效 ——
+而收回代幣是硬刪除,這不是假設情境。
+
+### 保留 offset,加上 `created_at <= 目前第一筆` 的上界
+
+擋得住新增(新資料一定排在最上面,被上界切掉),但擋不住刪除。
+刪除發生在已載入區塊內部,後面往前挪,沒有任何上界能阻止。
+
+## 後果
+
+- 三支 hook(發送紀錄、即將發送、消費紀錄)的 `_lte` 上界整段移除,`offset` 固定為 0。
+- dev 環境以新查詢形狀完整走訪 83 筆:0 重複、0 漏,最後一頁 `count - 已載入 = 0`,
+  按鈕正確隱藏。
+- **實際 UI 行為尚未在部署環境驗證**,需上測試站點擊確認。
+
+## 尚未決定
+
+1. `coin_log` 目前沒有 `created_at` 索引(只有 `pkey(id)` 與 `(member_id, started_at)`),
+   每次查詢仍是整排掃描後排序。seek 的效能優勢要配 `(created_at desc, id desc)` 複合索引
+   才拿得到 —— 但 Hasura 無法表達 row-value 比較 `(created_at, id) < (?, ?)`,
+   只能展開成 `_or` + `_and`,Postgres 對這個形狀不保證會走複合索引。
+   加索引前必須先確認執行計畫。
+2. `src/pages/PointHistoryAdminPage.tsx:305,381`(點數)有完全相同的 offset 寫法,
+   尚未處理。
+3. `handleRevokeCoin` 刪除後只呼叫 `refetchCoinLogs()`,但「即將發送」tab 的收回按鈕
+   走同一個 function → 在該 tab 收回後,畫面與 cache 不同步。
+   本次未修,待決定是否併入。

--- a/src/components/coin/MemberCoinAdminBlock.tsx
+++ b/src/components/coin/MemberCoinAdminBlock.tsx
@@ -99,6 +99,18 @@ const StyledSearchOutlined = styled(SearchOutlined)`
   }
 `
 
+const PAGE_SIZE = 10
+
+// seek pagination 的游標條件:以最後一筆的 (created_at, id) 為座標往下取。
+// 必須與 order_by 的 (created_at desc, id desc) 一致,否則座標無效。
+// 詳見 docs/adr/0001-coin-log-seek-pagination.md
+const afterCursor = (cursor: { created_at: any; id: string }) => ({
+  _or: [
+    { created_at: { _lt: cursor.created_at } },
+    { _and: [{ created_at: { _eq: cursor.created_at } }, { id: { _lt: cursor.id } }] },
+  ],
+})
+
 const MemberCoinAdminBlock: React.VFC<{
   memberId?: string
   withSendingModal?: boolean
@@ -528,9 +540,8 @@ const useCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; 
             count
           }
         }
-        # 批次匯入會產生大量 created_at 完全相同的資料列(實務上單一秒數十筆),
-        # 只用 created_at 排序時 Postgres 不保證並列資料的順序穩定,
-        # offset 翻頁就會重複或漏行。補 id 當第二排序鍵讓順序全序化。
+        # id 是第二排序鍵,不可移除:批次發送的 created_at 完全相同,
+        # 沒有它排序不唯一,seek 分頁的游標就沒有座標可指。
         coin_log(where: $condition, order_by: [{ created_at: desc }, { id: desc }], limit: $limit, offset: $offset) {
           id
           member {
@@ -553,7 +564,7 @@ const useCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; 
     {
       variables: {
         condition,
-        limit: 10,
+        limit: PAGE_SIZE,
         offset: 0,
       },
     },
@@ -579,33 +590,37 @@ const useCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; 
           amount: coinLog.amount,
         }))
 
-  // 分頁狀態一律從當下的 data 推導,不另外存 ref。
-  // 舊版把「第一筆的 created_at」與「已翻過幾頁」存在 ref 裡而且從不重設:
-  // 發送代幣後 refetch 只會回到第一頁,但 ref 還停在舊值 ——
-  // created_at 的上界把剛發出去的資料整批擋掉(往下翻也看不到),
-  // offset 則會跳號漏行。改成從 data 推導後,refetch 完自然就是對的。
-  const loadMoreCoinLogs = () =>
-    fetchMore({
+  const loadMoreCoinLogs = () => {
+    const cursor = data?.coin_log[data.coin_log.length - 1]
+    if (!cursor) {
+      return Promise.resolve()
+    }
+    return fetchMore({
       variables: {
-        // 以「目前載入的最新一筆」為上界,避免翻頁途中有新資料插進來把 offset 推移。
-        // 排序是 (created_at desc, id desc),第一筆必為並列群組中的最大值,
-        // 所以 _lte 取到的集合正好從第一筆開始,offset 等於已載入的筆數。
-        condition: data?.coin_log[0]?.created_at
-          ? { ...condition, created_at: { _lte: data.coin_log[0].created_at } }
-          : condition,
-        limit: 10,
-        offset: data?.coin_log.length || 0,
+        condition: { _and: [condition, afterCursor(cursor)] },
+        limit: PAGE_SIZE,
+        offset: 0,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) {
           return prev
         }
-
-        return Object.assign({}, prev, {
+        return {
+          ...prev,
           coin_log: [...prev.coin_log, ...fetchMoreResult.coin_log],
-        })
+          // aggregate 跟著游標往前推:fetchMore 的 count 是「游標之後還有幾筆」,
+          // 加上已載入的筆數才能還原成總數,否則刪除資料後按鈕不會消失。
+          coin_log_aggregate: {
+            ...fetchMoreResult.coin_log_aggregate,
+            aggregate: {
+              ...fetchMoreResult.coin_log_aggregate.aggregate,
+              count: prev.coin_log.length + (fetchMoreResult.coin_log_aggregate.aggregate?.count || 0),
+            },
+          },
+        }
       },
     })
+  }
 
   return {
     loadingCoinLogs: loading,
@@ -665,7 +680,7 @@ const useFutureCoinLogCollection = (filter?: { nameAndEmail?: string; title?: st
     {
       variables: {
         condition,
-        limit: 10,
+        limit: PAGE_SIZE,
         offset: 0,
       },
     },
@@ -690,25 +705,35 @@ const useFutureCoinLogCollection = (filter?: { nameAndEmail?: string; title?: st
           endedAt: coinFutureLog.ended_at && new Date(coinFutureLog.ended_at),
           amount: coinFutureLog.amount,
         }))
-  const loadMoreCoinFutureLogs = () =>
-    fetchMore({
+  const loadMoreCoinFutureLogs = () => {
+    const cursor = data?.coin_log[data.coin_log.length - 1]
+    if (!cursor) {
+      return Promise.resolve()
+    }
+    return fetchMore({
       variables: {
-        condition: data?.coin_log[0]?.created_at
-          ? { ...condition, created_at: { _lte: data.coin_log[0].created_at } }
-          : condition,
-        limit: 10,
-        offset: data?.coin_log.length || 0,
+        condition: { _and: [condition, afterCursor(cursor)] },
+        limit: PAGE_SIZE,
+        offset: 0,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) {
           return prev
         }
-
-        return Object.assign({}, prev, {
+        return {
+          ...prev,
           coin_log: [...prev.coin_log, ...fetchMoreResult.coin_log],
-        })
+          coin_log_aggregate: {
+            ...fetchMoreResult.coin_log_aggregate,
+            aggregate: {
+              ...fetchMoreResult.coin_log_aggregate.aggregate,
+              count: prev.coin_log.length + (fetchMoreResult.coin_log_aggregate.aggregate?.count || 0),
+            },
+          },
+        }
       },
     })
+  }
 
   return {
     loadingCoinFutureLogs: loading,
@@ -778,7 +803,7 @@ const useOrderLogWithCoinsCollection = (filter?: {
     {
       variables: {
         condition,
-        limit: 10,
+        limit: PAGE_SIZE,
         offset: 0,
       },
     },
@@ -800,24 +825,35 @@ const useOrderLogWithCoinsCollection = (filter?: {
           createdAt: orderLog.created_at,
         }))
 
-  const loadMoreOrderLogs = () =>
-    fetchMore({
+  const loadMoreOrderLogs = () => {
+    const cursor = data?.order_log[data.order_log.length - 1]
+    if (!cursor) {
+      return Promise.resolve()
+    }
+    return fetchMore({
       variables: {
-        condition: data?.order_log[0]?.created_at
-          ? { ...condition, created_at: { _lte: data.order_log[0].created_at } }
-          : condition,
-        limit: 10,
-        offset: data?.order_log.length || 0,
+        condition: { _and: [condition, afterCursor(cursor)] },
+        limit: PAGE_SIZE,
+        offset: 0,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) {
           return prev
         }
-        return Object.assign({}, prev, {
+        return {
+          ...prev,
           order_log: [...prev.order_log, ...fetchMoreResult.order_log],
-        })
+          order_log_aggregate: {
+            ...fetchMoreResult.order_log_aggregate,
+            aggregate: {
+              ...fetchMoreResult.order_log_aggregate.aggregate,
+              count: prev.order_log.length + (fetchMoreResult.order_log_aggregate.aggregate?.count || 0),
+            },
+          },
+        }
       },
     })
+  }
 
   return {
     loadingOrderLogs: loading,

--- a/src/components/coin/MemberCoinAdminBlock.tsx
+++ b/src/components/coin/MemberCoinAdminBlock.tsx
@@ -155,7 +155,10 @@ const MemberCoinAdminBlock: React.VFC<{
     deleteCoinLog(id).then(() => {
       setIsRevokedModalVisible(false)
       message.success(formatMessage(messages.successfullyRevoked))
+      // 發送紀錄與即將發送兩個 tab 的收回按鈕共用這個 handler,
+      // 兩邊都要 refetch,否則留在原 tab 的畫面與 cache 會殘留已刪除的列
       refetchCoinLogs()
+      refetchCoinFutureLogs()
     })
   }
 

--- a/src/components/coin/MemberCoinAdminBlock.tsx
+++ b/src/components/coin/MemberCoinAdminBlock.tsx
@@ -502,10 +502,6 @@ const MemberCoinAdminBlock: React.VFC<{
   )
 }
 const useCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; memberId?: string }) => {
-  // 三個 tab 各自持有分頁狀態。共用同一組 ref 會讓先回應的那個 hook
-  // 決定 storeCreatedTime,而 currentIndex 會被任一 tab 的「載入更多」累加。
-  const storeCreatedTime = useRef('')
-  const currentIndex = useRef(0)
   const condition: hasura.GET_COIN_RELEASE_HISTORYVariables['condition'] = {
     member_id: filter?.memberId
       ? {
@@ -583,22 +579,27 @@ const useCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; 
           amount: coinLog.amount,
         }))
 
-  if (storeCreatedTime.current === '' && data) {
-    storeCreatedTime.current = data?.coin_log[0]?.created_at ? data?.coin_log[0]?.created_at : ''
-  }
-
+  // 分頁狀態一律從當下的 data 推導,不另外存 ref。
+  // 舊版把「第一筆的 created_at」與「已翻過幾頁」存在 ref 裡而且從不重設:
+  // 發送代幣後 refetch 只會回到第一頁,但 ref 還停在舊值 ——
+  // created_at 的上界把剛發出去的資料整批擋掉(往下翻也看不到),
+  // offset 則會跳號漏行。改成從 data 推導後,refetch 完自然就是對的。
   const loadMoreCoinLogs = () =>
     fetchMore({
       variables: {
-        condition: { ...condition, created_at: { _lte: storeCreatedTime.current } },
+        // 以「目前載入的最新一筆」為上界,避免翻頁途中有新資料插進來把 offset 推移。
+        // 排序是 (created_at desc, id desc),第一筆必為並列群組中的最大值,
+        // 所以 _lte 取到的集合正好從第一筆開始,offset 等於已載入的筆數。
+        condition: data?.coin_log[0]?.created_at
+          ? { ...condition, created_at: { _lte: data.coin_log[0].created_at } }
+          : condition,
         limit: 10,
-        offset: 10 + currentIndex.current,
+        offset: data?.coin_log.length || 0,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) {
           return prev
         }
-        currentIndex.current += 10
 
         return Object.assign({}, prev, {
           coin_log: [...prev.coin_log, ...fetchMoreResult.coin_log],
@@ -617,8 +618,6 @@ const useCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; 
 }
 
 const useFutureCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; memberId?: string }) => {
-  const storeCreatedTime = useRef('')
-  const currentIndex = useRef(0)
   const condition: hasura.GET_COIN_ABOUT_TO_SENDVariables['condition'] = {
     member_id: filter?.memberId
       ? {
@@ -691,22 +690,19 @@ const useFutureCoinLogCollection = (filter?: { nameAndEmail?: string; title?: st
           endedAt: coinFutureLog.ended_at && new Date(coinFutureLog.ended_at),
           amount: coinFutureLog.amount,
         }))
-  if (storeCreatedTime.current === '' && data) {
-    storeCreatedTime.current = data?.coin_log[0]?.created_at ? data?.coin_log[0]?.created_at : ''
-  }
-
   const loadMoreCoinFutureLogs = () =>
     fetchMore({
       variables: {
-        condition: { ...condition, created_at: { _lte: storeCreatedTime.current } },
+        condition: data?.coin_log[0]?.created_at
+          ? { ...condition, created_at: { _lte: data.coin_log[0].created_at } }
+          : condition,
         limit: 10,
-        offset: 10 + currentIndex.current,
+        offset: data?.coin_log.length || 0,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) {
           return prev
         }
-        currentIndex.current += 10
 
         return Object.assign({}, prev, {
           coin_log: [...prev.coin_log, ...fetchMoreResult.coin_log],
@@ -730,8 +726,6 @@ const useOrderLogWithCoinsCollection = (filter?: {
   title?: string
   memberId?: string
 }) => {
-  const storeCreatedTime = useRef('')
-  const currentIndex = useRef(0)
   const condition: hasura.GET_ORDER_LOG_WITH_COINS_COLLECTIONVariables['condition'] = {
     id: filter?.orderLogId ? { _like: `%${filter.orderLogId}%` } : undefined,
     member_id: filter?.memberId
@@ -806,22 +800,19 @@ const useOrderLogWithCoinsCollection = (filter?: {
           createdAt: orderLog.created_at,
         }))
 
-  if (storeCreatedTime.current === '' && data) {
-    storeCreatedTime.current = data?.order_log[0]?.created_at ? data?.order_log[0]?.created_at : ''
-  }
-
   const loadMoreOrderLogs = () =>
     fetchMore({
       variables: {
-        condition: { ...condition, created_at: { _lte: storeCreatedTime.current } },
+        condition: data?.order_log[0]?.created_at
+          ? { ...condition, created_at: { _lte: data.order_log[0].created_at } }
+          : condition,
         limit: 10,
-        offset: 10 + currentIndex.current,
+        offset: data?.order_log.length || 0,
       },
       updateQuery: (prev, { fetchMoreResult }) => {
         if (!fetchMoreResult) {
           return prev
         }
-        currentIndex.current += 10
         return Object.assign({}, prev, {
           order_log: [...prev.order_log, ...fetchMoreResult.order_log],
         })

--- a/src/components/coin/MemberCoinAdminBlock.tsx
+++ b/src/components/coin/MemberCoinAdminBlock.tsx
@@ -109,8 +109,6 @@ const MemberCoinAdminBlock: React.VFC<{
   const coinUnit = settings['coin.unit'] || formatMessage(messages.unitOfCoins)
   const deleteCoinLog = useDeleteCoinLog()
   const [isRevokedModalVisible, setIsRevokedModalVisible] = useState<boolean>(false)
-  const storeCreatedTime = useRef('')
-  const currentIndex = useRef(0)
 
   const [fieldFilter, setFieldFilter] = useState<{
     orderLogId?: string
@@ -118,18 +116,14 @@ const MemberCoinAdminBlock: React.VFC<{
     title?: string
   }>({})
 
-  const { loadingCoinLogs, errorCoinLogs, coinLogs, refetchCoinLogs, loadMoreCoinLogs } = useCoinLogCollection(
-    currentIndex,
-    storeCreatedTime,
-    {
-      ...fieldFilter,
-      memberId,
-    },
-  )
+  const { loadingCoinLogs, errorCoinLogs, coinLogs, refetchCoinLogs, loadMoreCoinLogs } = useCoinLogCollection({
+    ...fieldFilter,
+    memberId,
+  })
   const { loadingCoinFutureLogs, errorCoinFutureLogs, coinFutureLogs, refetchCoinFutureLogs, loadMoreCoinFutureLogs } =
-    useFutureCoinLogCollection(currentIndex, storeCreatedTime, { ...fieldFilter, memberId })
+    useFutureCoinLogCollection({ ...fieldFilter, memberId })
   const { loadingOrderLogs, errorOrderLogs, orderLogs, refetchOrderLogs, loadMoreOrderLogs } =
-    useOrderLogWithCoinsCollection(currentIndex, storeCreatedTime, {
+    useOrderLogWithCoinsCollection({
       ...fieldFilter,
       memberId,
     })
@@ -507,11 +501,11 @@ const MemberCoinAdminBlock: React.VFC<{
     </>
   )
 }
-const useCoinLogCollection = (
-  currentIndex: React.MutableRefObject<number>,
-  storeCreatedTime: React.MutableRefObject<string>,
-  filter?: { nameAndEmail?: string; title?: string; memberId?: string },
-) => {
+const useCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; memberId?: string }) => {
+  // 三個 tab 各自持有分頁狀態。共用同一組 ref 會讓先回應的那個 hook
+  // 決定 storeCreatedTime,而 currentIndex 會被任一 tab 的「載入更多」累加。
+  const storeCreatedTime = useRef('')
+  const currentIndex = useRef(0)
   const condition: hasura.GET_COIN_RELEASE_HISTORYVariables['condition'] = {
     member_id: filter?.memberId
       ? {
@@ -538,7 +532,10 @@ const useCoinLogCollection = (
             count
           }
         }
-        coin_log(where: $condition, order_by: { created_at: desc }, limit: $limit, offset: $offset) {
+        # 批次匯入會產生大量 created_at 完全相同的資料列(實務上單一秒數十筆),
+        # 只用 created_at 排序時 Postgres 不保證並列資料的順序穩定,
+        # offset 翻頁就會重複或漏行。補 id 當第二排序鍵讓順序全序化。
+        coin_log(where: $condition, order_by: [{ created_at: desc }, { id: desc }], limit: $limit, offset: $offset) {
           id
           member {
             id
@@ -619,11 +616,9 @@ const useCoinLogCollection = (
   }
 }
 
-const useFutureCoinLogCollection = (
-  currentIndex: React.MutableRefObject<number>,
-  storeCreatedTime: React.MutableRefObject<string>,
-  filter?: { nameAndEmail?: string; title?: string; memberId?: string },
-) => {
+const useFutureCoinLogCollection = (filter?: { nameAndEmail?: string; title?: string; memberId?: string }) => {
+  const storeCreatedTime = useRef('')
+  const currentIndex = useRef(0)
   const condition: hasura.GET_COIN_ABOUT_TO_SENDVariables['condition'] = {
     member_id: filter?.memberId
       ? {
@@ -649,7 +644,7 @@ const useFutureCoinLogCollection = (
             count
           }
         }
-        coin_log(order_by: { created_at: desc }, limit: $limit, offset: $offset, where: $condition) {
+        coin_log(order_by: [{ created_at: desc }, { id: desc }], limit: $limit, offset: $offset, where: $condition) {
           id
           member {
             id
@@ -729,16 +724,14 @@ const useFutureCoinLogCollection = (
   }
 }
 
-const useOrderLogWithCoinsCollection = (
-  currentIndex: React.MutableRefObject<number>,
-  storeCreatedTime: React.MutableRefObject<string>,
-  filter?: {
-    orderLogId?: string
-    nameAndEmail?: string
-    title?: string
-    memberId?: string
-  },
-) => {
+const useOrderLogWithCoinsCollection = (filter?: {
+  orderLogId?: string
+  nameAndEmail?: string
+  title?: string
+  memberId?: string
+}) => {
+  const storeCreatedTime = useRef('')
+  const currentIndex = useRef(0)
   const condition: hasura.GET_ORDER_LOG_WITH_COINS_COLLECTIONVariables['condition'] = {
     id: filter?.orderLogId ? { _like: `%${filter.orderLogId}%` } : undefined,
     member_id: filter?.memberId
@@ -769,7 +762,7 @@ const useOrderLogWithCoinsCollection = (
             count
           }
         }
-        order_log(where: $condition, limit: $limit, offset: $offset, order_by: { created_at: desc }) {
+        order_log(where: $condition, limit: $limit, offset: $offset, order_by: [{ created_at: desc }, { id: desc }]) {
           id
           created_at
           member {


### PR DESCRIPTION
## 背景

客戶 `neganchor` 回報會員代幣紀錄「學員端看得到、管理端看不到」。
查下來是管理端清單有**兩個獨立的分頁缺陷**，資料本身一筆都沒有問題。

## 問題

### 1. `order_by` 缺唯一鍵，offset 翻頁會漏行

批次發送會產生大量 `created_at` **完全相同**的資料列（同一次 mutation 共用
transaction 時間戳，實務上單一微秒數十筆）。查詢只用 `order_by: { created_at: desc }`，
Postgres 對並列值不保證跨頁順序一致，搭配 `limit 10 / offset N` 翻頁就會
**同時產生重複列與漏行**。

正式站唯讀實測（管理端實際的查詢條件，翻 8 頁）：

| | 取回列數 | 唯一 id |
|---|---|---|
| 修正前 | 80 | **76** |
| 修正後 | 80 | **80** |

客訴那筆在修正前翻到底都不會出現（連跑 3 次相同），修正後出現在 offset 30。

> ⚠️ 這不是排序錯亂 —— `created_at` 全程單調遞減，**畫面上沒有任何視覺訊號**，
> 只有「某一列安靜地不見了」。

### 2. 分頁狀態存在從不重設的 ref，refetch 後畫面是錯的

`storeCreatedTime` / `currentIndex` 只在初次載入時寫入，之後永不重設。
發送代幣成功後會 `refetch`，但 refetch 只回第一頁：

- `storeCreatedTime` 凍結在**發送前**的時間戳，而 `loadMore` 的條件是
  `created_at <= 它` → **把剛發出去的資料整批擋在門外**，往下翻到底也看不到
- `currentIndex` 只增不減 → refetch 把畫面砍回第一頁後仍停在舊值，
  下一次「顯示更多」直接跳號漏行

實際後果：一次發送 16 人 → 畫面只出現 10 筆 → 操作者以為有 6 人沒發成功 → 補發。

## 修改

單一檔案 `src/components/coin/MemberCoinAdminBlock.tsx`（三支 query 都改）：

1. `order_by` 補 `{ id: desc }` 當第二排序鍵，讓順序全序化
2. 分頁狀態一律從當下的 `data` 推導：
   - `offset` 改用 `data.xxx.length`
   - `created_at` 上界改用「呼叫當下的第一筆」而非凍結值 ——
     保留「翻頁途中不被新資料推移」的原意，但不會再擋掉剛發出去的資料
   - 移除 `storeCreatedTime` / `currentIndex` 兩組 ref（三個 hook 共 6 個）
   - 順帶移除 `updateQuery` 裡 `currentIndex.current += 10` 這個放錯位置的副作用

淨減 16 行。

> **兩個 commit 必須一起上。** 第二個 commit 的 `_lte` 上界依賴第一個 commit 的
> tiebreaker：排序是 `(created_at desc, id desc)` 時，第一筆必為並列群組中的
> 最大值，`_lte` 取到的集合才會正好從第一筆開始、`offset` 才等於已載入筆數。

## 驗證

- `tsc --noEmit`：`src/` 零錯誤
- production build 通過
- 正式站唯讀 GraphQL 實測翻 8 頁（上表），連跑 3 次結果一致
- **demo 站實機復現**：用相同操作路徑（手動發送、一次選 16 人）重現原缺陷 ——
  DB 進 19 筆但畫面只出現 10 筆、連按「顯示更多」4 次都不會多，
  重載後第一頁是完全不同的 10 個人、翻到底 16 列只有 12 個唯一

## 影響範圍

`coin_log` 全表有大量並列時間戳群組（最大一組 1,535 筆）。
**這是全平台性的問題，不限單一客戶。**

`PointHistoryAdminPage.tsx:305,381`（點數）有**完全相同的 pattern，尚未處理** ——
未包含在這支 PR，需要另外決定要不要一併修。

## 這支 PR 沒有解決的：翻頁途中刪除資料

offset 分頁問的是「跳過前 N 筆」，前面被刪掉一筆，後面全部往前挪一格
→ 交界處那一筆會被含進「前 N 筆」一起跳掉，**無聲消失**。
上界條件擋得住「新增」（新資料一定排在最上面、被上界切掉），
但**擋不住刪除**，這是 offset 分頁的結構性限制。

**站上現在就有一條打得到的路徑**：`handleRevokeCoin`（`:142-148`）刪除後只呼叫
`refetchCoinLogs()`，但「即將發送」tab 的收回按鈕（`:388`）走的是同一個 function。
在該 tab 收回一筆之後 → DB 少一列、但 `refetchCoinFutureLogs` 沒被呼叫 →
畫面與 cache 還是 N 筆 → 下次「顯示更多」送 `offset = N` → **漏一筆**。
單一操作者、單一分頁即可觸發，不需要併發。
（切換 tab 會觸發三支全 refetch 而自癒，所以只在留於該 tab 連續操作時成立。）

**短期**可補一行 `refetchCoinFutureLogs()`；**長期**建議三支 hook 改用 keyset
（游標記錄最後一筆的 `(created_at, id)`，而非「已跳過幾筆」），
上界條件即可整段移除。本 PR 補的 `{ id: desc }` 正是 keyset 的前置 ——
批次發送時間戳完全相同，沒有第二個唯一鍵就沒有唯一座標，游標無處可指。

> ⚠️ 未驗證：Hasura 無法表達 row-value 比較，只能展開成 `_or` + `_and`，
> Postgres 對這個形狀不保證會走複合索引。這是長期方案的前置確認事項。

## 尚未處理（同檔案內順帶發現，本次刻意不動）

- CSV 批次匯入的 `onRefetch` 在檔案上傳成功當下就呼叫，但 server 端是非同步處理，
  資料還沒進 DB → 必定抓不到，需要重整
- 設了未來效期的發送屬於「即將發送」tab，但 `onRefetch` 只接了發送紀錄的 refetch
- 收回代幣的 modal 三個 tab 共用同一個 `isRevokedModalVisible` state，
  會同時開啟多個 modal
