### PR TITLE
fix: 業績總表「查看同機構業績／查看同組別業績」權限範圍區分

### DIFF
--- a/src/pages/SalesPerformancePage/SalesPerformancePage.tsx
+++ b/src/pages/SalesPerformancePage/SalesPerformancePage.tsx
@@ -1,7 +1,7 @@
 import Icon, { DollarOutlined } from '@ant-design/icons'
 import { gql, useQuery } from '@apollo/client'
 import { Box } from '@chakra-ui/layout'
-import { DatePicker, Select, Skeleton, Table } from 'antd'
+import { Alert, DatePicker, Select, Skeleton, Table } from 'antd'
 import { ColumnsType } from 'antd/lib/table'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import moment from 'moment-timezone'
@@ -73,17 +73,26 @@ const SalesPerformancePage: React.VFC = () => {
 
   const isAdminPermission = currentUserRole === 'app-owner' || Boolean(permissions.SALES_PERFORMANCE_ADMIN)
 
-  useEffect(() => {
-    if (!currentMemberDepartmentLoading) {
-      currentMemberDepartment && setActiveDepartment(currentMemberDepartment)
-    }
-  }, [currentMemberDepartment, currentMemberDepartmentLoading])
+  // effective viewing scope, larger permission wins: admin > department (同機構) > division (同組別)
+  const scope: 'admin' | 'department' | 'division' | 'callOnly' = isAdminPermission
+    ? 'admin'
+    : permissions.SALES_VIEW_SAME_DEPARTMENT_PERFORMANCE_ADMIN
+    ? 'department'
+    : permissions.SALES_VIEW_SAME_DIVISION_PERFORMANCE_ADMIN
+    ? 'division'
+    : 'callOnly'
 
   useEffect(() => {
-    if (!loadingCurrentMemberDivision) {
+    if (scope !== 'admin' && !currentMemberDepartmentLoading) {
+      currentMemberDepartment && setActiveDepartment(currentMemberDepartment)
+    }
+  }, [currentMemberDepartment, currentMemberDepartmentLoading, scope])
+
+  useEffect(() => {
+    if ((scope === 'division' || scope === 'callOnly') && !loadingCurrentMemberDivision) {
       currentMemberDivision && setActiveGroupName(currentMemberDivision)
     }
-  }, [currentMemberDivision, loadingCurrentMemberDivision])
+  }, [currentMemberDivision, loadingCurrentMemberDivision, scope])
 
   if (
     !permissions.SALES_VIEW_SAME_DIVISION_PERFORMANCE_ADMIN &&
@@ -93,6 +102,13 @@ const SalesPerformancePage: React.VFC = () => {
   ) {
     return <ForbiddenPage />
   }
+
+  // scoped viewers must have the member properties their scope locks onto;
+  // falling back to an unfiltered view would leak data outside their scope
+  const missingScopeProperty =
+    (scope === 'department' || scope === 'division') &&
+    ((!currentMemberDepartmentLoading && !currentMemberDepartment) ||
+      (scope === 'division' && !loadingCurrentMemberDivision && !currentMemberDivision))
 
   const filterMemberContracts = activeManagerId
     ? activeGroupName
@@ -136,9 +152,7 @@ const SalesPerformancePage: React.VFC = () => {
         </span>
       </AdminPageTitle>
       <Box className="d-flex flex-wrap mb-4">
-        {isAdminPermission ||
-        Boolean(isAdminPermission && permissions.SALES_VIEW_SAME_DEPARTMENT_PERFORMANCE_ADMIN) ||
-        !Boolean(permissions.SALES_VIEW_SAME_DEPARTMENT_PERFORMANCE_ADMIN) ? (
+        {scope === 'admin' || scope === 'callOnly' ? (
           <Select
             className="mr-3"
             style={{ width: 200 }}
@@ -150,12 +164,7 @@ const SalesPerformancePage: React.VFC = () => {
             onChange={v => {
               setActiveDepartment(v)
               setActiveManagerId(undefined)
-              if (
-                isAdminPermission ||
-                (isAdminPermission && permissions.SALES_VIEW_SAME_DIVISION_PERFORMANCE_ADMIN) ||
-                !Boolean(permissions.SALES_VIEW_SAME_DIVISION_PERFORMANCE_ADMIN)
-              )
-                setActiveGroupName(undefined)
+              setActiveGroupName(undefined)
             }}
           >
             {uniqBy(manager => manager.department, managers || []).map(manager => (
@@ -165,9 +174,7 @@ const SalesPerformancePage: React.VFC = () => {
             ))}
           </Select>
         ) : null}
-        {isAdminPermission ||
-        (isAdminPermission && permissions.SALES_VIEW_SAME_DIVISION_PERFORMANCE_ADMIN) ||
-        !Boolean(permissions.SALES_VIEW_SAME_DIVISION_PERFORMANCE_ADMIN) ? (
+        {scope !== 'division' ? (
           <Select
             className="mr-3"
             style={{ width: 200 }}
@@ -219,7 +226,13 @@ const SalesPerformancePage: React.VFC = () => {
         <DatePicker className="mr-2 mb-10" picker="month" onChange={date => date && setMonth(date.startOf('month'))} />
       </Box>
 
-      {currentMemberId ? (
+      {missingScopeProperty ? (
+        <Alert
+          showIcon
+          type="warning"
+          message={formatMessage(pageMessages.SalesPerformancePage.missingScopePropertyNotice)}
+        />
+      ) : currentMemberId ? (
         <SalesPerformanceTable loading={loading} memberContracts={filterMemberContracts} />
       ) : (
         <Skeleton active />

--- a/src/pages/translation.ts
+++ b/src/pages/translation.ts
@@ -705,6 +705,10 @@ const pageMessages = {
   SalesPerformancePage: defineMessages({
     departmentPlaceholder: { id: 'page.SalesPerformancePage.departmentPlaceholder', defaultMessage: '機構' },
     groupPlaceholder: { id: 'page.SalesPerformancePage.groupPlaceholder', defaultMessage: '組別' },
+    missingScopePropertyNotice: {
+      id: 'page.SalesPerformancePage.missingScopePropertyNotice',
+      defaultMessage: '尚未設定您的機構／組別會員屬性，暫時無法顯示業績資料，請聯絡管理員。',
+    },
     managerPlaceholder: { id: 'page.SalesPerformancePage.managerPlaceholder', defaultMessage: '業務顧問' },
     signedDate: { id: 'page.SalesPerformancePage.signedDate', defaultMessage: '簽署日' },
     approvedDate: { id: 'page.SalesPerformancePage.approvedDate', defaultMessage: '通過日' },


### PR DESCRIPTION
## 問題

客戶回報:權限群組「業績總表」的「查看同機構業績」與「查看同組別業績」兩種權限,在業績總表頁看到的資料完全相同。

## 根因

- 2024-04 `ecd8f268` 導入組別權限後,前端仍不分權限、一律把「機構」「組別」篩選預設成使用者自己的會員屬性,因此兩種權限的落地畫面完全相同(自己機構+自己組別)。
- 下拉顯示條件是恆真式 `isAdmin || (isAdmin && X) || !X`(≡ `isAdmin || !X`,中間項為死碼),導致「同組別」使用者反而看得到機構下拉、「同機構」使用者看不到。
- 使用者缺「組別」會員屬性時,組別鎖定靜默失效,退化成整機構資料。
- Hasura 資料層兩種權限皆未實作列級範圍(同機構=全站、同組別=無授權);本次依決策**僅調整前端**,資料層詳見工作區 `SALES-PERFORMANCE-PERMISSION-FIX-PLAN.zh-TW.md`。

## 修改內容

1. 新增有效權限範圍 `scope`,大權限優先:`admin` > `department`(同機構) > `division`(同組別) > `callOnly`(僅 SALES_CALL_ADMIN,維持現狀)。
2. 「組別」篩選只在 `division` / `callOnly` 才預設 → **同機構使用者進頁即看整個機構**(本次客訴的直接修正)。
3. 下拉顯示條件修正:機構下拉僅 `admin` / `callOnly` 顯示;組別下拉對 `division` 隱藏(鎖定)。
4. 缺機構/組別屬性時改顯示警告(新 i18n key `page.SalesPerformancePage.missingScopePropertyNotice`),不再靜默顯示未過濾資料。

## 行為對照

| 權限 | 機構下拉 | 組別下拉 | 預設篩選 | 可見範圍 |
|---|---|---|---|---|
| admin(app-owner / 所有業績總表) | 顯示 | 顯示 | 不預設 | 全站 |
| 查看同機構業績 | 隱藏(鎖定) | 顯示 | 機構=自己 | 整個機構,可切組別 |
| 查看同組別業績 | 隱藏(鎖定) | 隱藏(鎖定) | 機構+組別=自己 | 僅自己組別 |
| 僅 SALES_CALL_ADMIN | 顯示 | 顯示 | 機構+組別=自己 | 維持現狀 |

## 測試項目

- [ ] 只勾「查看同機構業績」:鎖定自己機構、預設顯示整機構、可切組別
- [ ] 只勾「查看同組別業績」:僅自己組別、無任何下拉可放大範圍
- [ ] 兩者皆勾:以同機構行為為準
- [ ] 同組別使用者無「組別」屬性:顯示警告而非全部資料
- [ ] admin / app-owner、SALES_CALL_ADMIN 行為不受影響(admin 不再預設帶入自己機構/組別)

## 注意事項

- 同組別使用者的資料來源仍依賴群組內其他權限(如 `MEMBER_CONTRACT_VIEW`);Hasura 本次未調整。
- 租戶業務人員需已設定「機構」「組別」會員屬性,否則會看到警告訊息。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
